### PR TITLE
fix(biome): enable tailwind directives and css support

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.2.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.3/schema.json",
   "files": {
     "ignoreUnknown": false
   },
@@ -66,6 +66,17 @@
   "json": {
     "formatter": {
       "trailingCommas": "none"
+    }
+  },
+  "css": {
+    "parser": {
+      "cssModules": true,
+      "tailwindDirectives": true
+    },
+    "formatter": {
+      "enabled": true,
+      "indentStyle": "space",
+      "indentWidth": 2
     }
   }
 }


### PR DESCRIPTION
Updates biome.json schema to 2.3.3 and enables parsing for Tailwind directives and CSS modules to fix linting errors.