### PR TITLE
[codex] Add coding agent integrations docs

### DIFF
--- a/content/docs/integrations/browser-use/integrations-overview.mdx
+++ b/content/docs/integrations/browser-use/integrations-overview.mdx
@@ -2,7 +2,7 @@
 title: Overview
 sidebarTitle: Overview
 description: Browser-Use is an open-source library that enables AI agents to control and interact with browsers programmatically. This integration connects Browser-Use with Steel's infrastructure, allowing for seamless automation of web tasks and workflows.
-llm: false
+llm: true
 ---
 ### Overview
 

--- a/content/docs/integrations/claude-computer-use/integrations-overview.mdx
+++ b/content/docs/integrations/claude-computer-use/integrations-overview.mdx
@@ -2,7 +2,7 @@
 title: Overview
 sidebarTitle: Overview
 description: Claude Computer Use employs vision-based AI to control browsers by continuously analyzing visual feedback, making decisions, and taking actions in a dynamic loop until the task is completed or a certain threshold is reached.
-llm: false
+llm: true
 ---
 #### Overview
 

--- a/content/docs/integrations/coding-agents/claude-code.mdx
+++ b/content/docs/integrations/coding-agents/claude-code.mdx
@@ -1,0 +1,134 @@
+---
+title: Claude Code
+sidebarTitle: Claude Code
+description: Use Claude Code with Steel CLI to drive real browser sessions, scrape rendered pages, and monitor browser workflows from the terminal.
+llm: true
+---
+
+### Overview
+
+The Claude Code integration uses Steel CLI as a terminal tool inside Claude Code. This lets Claude Code:
+
+*   Start and control Steel browser sessions from the terminal
+
+*   Use `steel scrape` for rendered page extraction
+
+*   Inspect live browser state with snapshots and the Steel session viewer
+
+*   Turn successful browser runs into repeatable scripts or project-specific workflows
+
+
+Claude Code already works well with local tools and shell commands. Steel extends that model with a real cloud browser for sites that need JavaScript, session state, or interactive navigation.
+
+### Requirements
+
+*   **Node.js**: Version 18 or higher
+
+*   **Claude Code**: Installed locally
+
+*   **Steel CLI**: Installed locally
+
+*   **Steel API Key**: Active Steel account
+
+
+### Setup
+
+#### Step 1: Install Steel CLI
+
+```bash Terminal
+curl -LsSf https://setup.steel.dev | sh
+```
+
+Or via npm:
+
+```bash Terminal
+npm i -g @steel-dev/cli
+```
+
+#### Step 2: Log in
+
+```bash Terminal
+steel login
+```
+
+#### Step 3: Install the browser skill (recommended)
+
+The `steel-browser` skill gives Claude Code better command discovery and more reliable browser workflows.
+
+```bash Terminal
+npx skills add github:steel-dev/cli/skills/steel-browser
+```
+
+Restart Claude Code after installing so it can discover the skill.
+
+### Example: Run a browser session
+
+Once Steel CLI is available, Claude Code can use it directly:
+
+```bash Terminal -wc
+steel browser start --session docs-review
+steel browser open https://docs.steel.dev --session docs-review
+steel browser snapshot -i --session docs-review
+steel browser stop --session docs-review
+```
+
+This is the core workflow for page inspection, navigation, clicking, form entry, and other multi-step browser tasks.
+
+### Example: Scrape a rendered page
+
+For tasks that only need page content, `steel scrape` is often faster:
+
+```bash Terminal
+steel scrape https://example.com
+```
+
+That makes it a good fit for summarization, extraction, and research tasks where the page needs to be rendered first but does not require interaction.
+
+### Authenticated workflows
+
+For authenticated sites, it is better to prepare reusable auth state in Steel ahead of time rather than asking Claude Code to handle login from scratch during every run.
+
+See:
+
+*   [Profiles API](/overview/profiles-api/overview)
+
+*   [Reusing Auth Context](/overview/sessions-api/reusing-auth-context)
+
+
+### Live debugging
+
+Steel sessions return a viewer URL that makes it easier to monitor what the browser is doing in real time. This is useful when Claude Code reaches a modal, a sign-in wall, or a page that does not behave as expected.
+
+### Repeatable workflows
+
+After a successful run, Claude Code can help turn the browser workflow into something more repeatable:
+
+*   A bash script for local execution
+
+*   A project-specific command or workflow
+
+*   A documented runbook for recurring tasks
+
+
+### Constraints
+
+*   **Command approvals depend on your Claude Code settings.** Shell access may require approval depending on your permission mode.
+
+*   **First runs are usually the roughest.** Dynamic web apps often need a few retries before the workflow is stable.
+
+*   **Authenticated sites work best with prepared Steel auth state.** Reusing profiles or auth context is generally more reliable than repeated interactive logins.
+
+
+### Additional Resources
+
+*   [Give Claude Code a real browser](https://steel.dev/blog/give-claude-code-a-real-browser) – Blog post on using Claude Code with Steel
+
+*   [Claude Code overview](https://code.claude.com/docs/en/overview) – Official Claude Code documentation
+
+*   [How Claude Code works](https://code.claude.com/docs/en/how-claude-code-works) – Built-in tools, permissions, and execution model
+
+*   [Steel CLI docs](/overview/steel-cli) – Full command reference and workflows
+
+*   [Steel browser skill](https://github.com/steel-dev/cli/tree/main/skills/steel-browser) – Skill package for coding agents
+
+*   [Discord](https://discord.gg/steel-dev) – Get help and share what you build

--- a/content/docs/integrations/coding-agents/claude-code.mdx
+++ b/content/docs/integrations/coding-agents/claude-code.mdx
@@ -7,29 +7,21 @@ llm: true
 
 ### Overview
 
-The Claude Code integration uses Steel CLI as a terminal tool inside Claude Code. This lets Claude Code:
+The Claude Code integration uses Steel CLI as a terminal tool through agent skill steel-browser. This lets Claude Code:
 
-*   Start and control Steel browser sessions from the terminal
-
-*   Use `steel scrape` for rendered page extraction
-
+*   Start and control Steel browser sessions from the Claude session
+*   Scrape fully rendered pages and perform computer-use actions
 *   Inspect live browser state with snapshots and the Steel session viewer
-
 *   Turn successful browser runs into repeatable scripts or project-specific workflows
-
 
 Claude Code already works well with local tools and shell commands. Steel extends that model with a real cloud browser for sites that need JavaScript, session state, or interactive navigation.
 
 ### Requirements
 
 *   **Node.js**: Version 18 or higher
-
 *   **Claude Code**: Installed locally
-
 *   **Steel CLI**: Installed locally
-
 *   **Steel API Key**: Active Steel account
-
 
 ### Setup
 
@@ -37,12 +29,6 @@ Claude Code already works well with local tools and shell commands. Steel extend
 
 ```bash Terminal
 curl -LsSf https://setup.steel.dev | sh
-```
-
-Or via npm:
-
-```bash Terminal
-npm i -g @steel-dev/cli
 ```
 
 #### Step 2: Log in
@@ -56,33 +42,12 @@ steel login
 The `steel-browser` skill gives Claude Code better command discovery and more reliable browser workflows.
 
 ```bash Terminal
-npx skills add github:steel-dev/cli/skills/steel-browser
+npx skills add https://github.com/steel-dev/cli --skill steel-browser
 ```
 
 Restart Claude Code after installing so it can discover the skill.
 
-### Example: Run a browser session
-
 Once Steel CLI is available, Claude Code can use it directly:
-
-```bash Terminal -wc
-steel browser start --session docs-review
-steel browser open https://docs.steel.dev --session docs-review
-steel browser snapshot -i --session docs-review
-steel browser stop --session docs-review
-```
-
-This is the core workflow for page inspection, navigation, clicking, form entry, and other multi-step browser tasks.
-
-### Example: Scrape a rendered page
-
-For tasks that only need page content, `steel scrape` is often faster:
-
-```bash Terminal
-steel scrape https://example.com
-```
-
-That makes it a good fit for summarization, extraction, and research tasks where the page needs to be rendered first but does not require interaction.
 
 ### Authenticated workflows
 
@@ -91,44 +56,33 @@ For authenticated sites, it is better to prepare reusable auth state in Steel ah
 See:
 
 *   [Profiles API](/overview/profiles-api/overview)
-
 *   [Reusing Auth Context](/overview/sessions-api/reusing-auth-context)
 
 
 ### Live debugging
 
-Steel sessions return a viewer URL that makes it easier to monitor what the browser is doing in real time. This is useful when Claude Code reaches a modal, a sign-in wall, or a page that does not behave as expected.
+Steel sessions return a viewer URL that makes it easier to monitor what the agent is doing in real time. This is useful when Claude Code reaches a modal, a sign-in wall, or a page that does not behave as expected.
 
 ### Repeatable workflows
 
 After a successful run, Claude Code can help turn the browser workflow into something more repeatable:
 
 *   A bash script for local execution
-
 *   A project-specific command or workflow
-
 *   A documented runbook for recurring tasks
-
 
 ### Constraints
 
 *   **Command approvals depend on your Claude Code settings.** Shell access may require approval depending on your permission mode.
-
 *   **First runs are usually the roughest.** Dynamic web apps often need a few retries before the workflow is stable.
-
 *   **Authenticated sites work best with prepared Steel auth state.** Reusing profiles or auth context is generally more reliable than repeated interactive logins.
 
 
 ### Additional Resources
 
 *   [Give Claude Code a real browser](https://steel.dev/blog/give-claude-code-a-real-browser) – Blog post on using Claude Code with Steel
-
 *   [Claude Code overview](https://code.claude.com/docs/en/overview) – Official Claude Code documentation
-
 *   [How Claude Code works](https://code.claude.com/docs/en/how-claude-code-works) – Built-in tools, permissions, and execution model
-
 *   [Steel CLI docs](/overview/steel-cli) – Full command reference and workflows
-
 *   [Steel browser skill](https://github.com/steel-dev/cli/tree/main/skills/steel-browser) – Skill package for coding agents
-
 *   [Discord](https://discord.gg/steel-dev) – Get help and share what you build

--- a/content/docs/integrations/coding-agents/codex.mdx
+++ b/content/docs/integrations/coding-agents/codex.mdx
@@ -1,0 +1,124 @@
+---
+title: Codex
+sidebarTitle: Codex
+description: Use Codex with Steel CLI to scrape pages, run browser sessions, and automate browser workflows from the terminal.
+llm: true
+---
+
+### Overview
+
+The Codex integration uses Steel CLI as a terminal tool inside Codex. This lets Codex:
+
+*   Scrape rendered pages with `steel scrape`
+
+*   Start and control browser sessions with `steel browser`
+
+*   Turn one-off browser runs into reusable scripts
+
+
+Codex and Steel fit together well because both are command-line tools. Once Steel CLI is installed and available on `PATH`, Codex can inspect command help, run the commands it needs, and verify results from the terminal.
+
+### Requirements
+
+*   **Node.js**: Version 18 or higher
+
+*   **Codex CLI**: Installed locally
+
+*   **Steel CLI**: Installed locally
+
+*   **Steel API Key**: Active Steel account
+
+
+### Setup
+
+#### Step 1: Install Steel CLI
+
+```bash Terminal
+curl -LsSf https://setup.steel.dev | sh
+```
+
+Or via npm:
+
+```bash Terminal
+npm i -g @steel-dev/cli
+```
+
+#### Step 2: Log in
+
+```bash Terminal
+steel login
+```
+
+#### Step 3: Install the browser skill (recommended)
+
+The `steel-browser` skill gives Codex better command discovery and more consistent browser workflows.
+
+```bash Terminal
+npx skills add github:steel-dev/cli/skills/steel-browser
+```
+
+Restart Codex after installing so it can discover the skill.
+
+### Example: Scrape a rendered page
+
+For read-heavy tasks, `steel scrape` is usually the simplest path. It renders the page in Steel's cloud browser and returns markdown output:
+
+```bash Terminal
+steel scrape https://news.ycombinator.com
+```
+
+This works well for tasks like summarization, extraction, ranking, and follow-up automation inside the same Codex session.
+
+### Example: Run a browser session
+
+For multi-step workflows, use a full browser session:
+
+```bash Terminal -wc
+steel browser start --session research
+steel browser open https://example.com --session research
+steel browser snapshot -i --session research
+steel browser click @e3 --session research
+steel browser stop --session research
+```
+
+This gives Codex a real browser loop for navigation, clicking, form entry, and session-aware browsing.
+
+### Automation workflow
+
+After a successful manual run, you can ask Codex to turn the workflow into a script:
+
+```
+Write a bash script based on what you just did.
+```
+
+That works well for jobs like recurring research, internal reporting, or lightweight monitoring. A common pattern is:
+
+1.  Run the task once interactively
+
+2.  Convert it into a script
+
+3.  Schedule it with cron or another runner
+
+
+### Constraints
+
+*   **Command approvals depend on your Codex settings.** Codex may ask before running shell commands unless you have configured a more permissive approval mode.
+
+*   **`steel scrape` returns markdown-first output.** For precise interaction or element targeting, use a browser session instead.
+
+*   **Authenticated workflows usually need preconfigured Steel auth state.** For reusable login state, see [Profiles API](/overview/profiles-api/overview) and [Reusing Auth Context](/overview/sessions-api/reusing-auth-context).
+
+
+### Additional Resources
+
+*   [Codex + Steel + Resend blog post](https://steel.dev/blog/codex-wired-steel-and-resend-into-a-daily-newsletter) – Example workflow for building a daily newsletter with Codex
+
+*   [Codex CLI Docs](https://developers.openai.com/codex/cli) – Install and use Codex locally
+
+*   [Steel CLI docs](/overview/steel-cli) – Full command reference and workflows
+
+*   [Steel browser skill](https://github.com/steel-dev/cli/tree/main/skills/steel-browser) – Skill package for coding agents
+
+*   [Get a free API key](https://app.steel.dev) – Sign up and start a session
+
+*   [Discord](https://discord.gg/steel-dev) – Get help and share what you build

--- a/content/docs/integrations/coding-agents/codex.mdx
+++ b/content/docs/integrations/coding-agents/codex.mdx
@@ -7,27 +7,21 @@ llm: true
 
 ### Overview
 
-The Codex integration uses Steel CLI as a terminal tool inside Codex. This lets Codex:
+The Codex integration uses Steel CLI as a terminal tool inside Codex with the help of steel-browser agent skill. This lets Codex:
 
-*   Scrape rendered pages with `steel scrape`
-
-*   Start and control browser sessions with `steel browser`
-
+*   Start and control Steel browser sessions from the Codex session
+*   Scrape fully rendered pages and perform computer-use actions
+*   Inspect live browser state with snapshots and the Steel session viewer
 *   Turn one-off browser runs into reusable scripts
-
 
 Codex and Steel fit together well because both are command-line tools. Once Steel CLI is installed and available on `PATH`, Codex can inspect command help, run the commands it needs, and verify results from the terminal.
 
 ### Requirements
 
 *   **Node.js**: Version 18 or higher
-
 *   **Codex CLI**: Installed locally
-
 *   **Steel CLI**: Installed locally
-
 *   **Steel API Key**: Active Steel account
-
 
 ### Setup
 
@@ -35,12 +29,6 @@ Codex and Steel fit together well because both are command-line tools. Once Stee
 
 ```bash Terminal
 curl -LsSf https://setup.steel.dev | sh
-```
-
-Or via npm:
-
-```bash Terminal
-npm i -g @steel-dev/cli
 ```
 
 #### Step 2: Log in
@@ -54,32 +42,10 @@ steel login
 The `steel-browser` skill gives Codex better command discovery and more consistent browser workflows.
 
 ```bash Terminal
-npx skills add github:steel-dev/cli/skills/steel-browser
+npx skills add https://github.com/steel-dev/cli --skill steel-browser
 ```
 
 Restart Codex after installing so it can discover the skill.
-
-### Example: Scrape a rendered page
-
-For read-heavy tasks, `steel scrape` is usually the simplest path. It renders the page in Steel's cloud browser and returns markdown output:
-
-```bash Terminal
-steel scrape https://news.ycombinator.com
-```
-
-This works well for tasks like summarization, extraction, ranking, and follow-up automation inside the same Codex session.
-
-### Example: Run a browser session
-
-For multi-step workflows, use a full browser session:
-
-```bash Terminal -wc
-steel browser start --session research
-steel browser open https://example.com --session research
-steel browser snapshot -i --session research
-steel browser click @e3 --session research
-steel browser stop --session research
-```
 
 This gives Codex a real browser loop for navigation, clicking, form entry, and session-aware browsing.
 
@@ -94,31 +60,20 @@ Write a bash script based on what you just did.
 That works well for jobs like recurring research, internal reporting, or lightweight monitoring. A common pattern is:
 
 1.  Run the task once interactively
-
 2.  Convert it into a script
-
 3.  Schedule it with cron or another runner
-
 
 ### Constraints
 
 *   **Command approvals depend on your Codex settings.** Codex may ask before running shell commands unless you have configured a more permissive approval mode.
-
-*   **`steel scrape` returns markdown-first output.** For precise interaction or element targeting, use a browser session instead.
-
 *   **Authenticated workflows usually need preconfigured Steel auth state.** For reusable login state, see [Profiles API](/overview/profiles-api/overview) and [Reusing Auth Context](/overview/sessions-api/reusing-auth-context).
 
 
 ### Additional Resources
 
 *   [Codex + Steel + Resend blog post](https://steel.dev/blog/codex-wired-steel-and-resend-into-a-daily-newsletter) – Example workflow for building a daily newsletter with Codex
-
-*   [Codex CLI Docs](https://developers.openai.com/codex/cli) – Install and use Codex locally
-
+*   [Codex CLI docs](https://developers.openai.com/codex/cli) – Install and use Codex locally
 *   [Steel CLI docs](/overview/steel-cli) – Full command reference and workflows
-
 *   [Steel browser skill](https://github.com/steel-dev/cli/tree/main/skills/steel-browser) – Skill package for coding agents
-
 *   [Get a free API key](https://app.steel.dev) – Sign up and start a session
-
 *   [Discord](https://discord.gg/steel-dev) – Get help and share what you build

--- a/content/docs/integrations/coding-agents/hermes-agent.mdx
+++ b/content/docs/integrations/coding-agents/hermes-agent.mdx
@@ -6,7 +6,7 @@ llm: true
 ---
 
 :::callout
-The Steel integration for Hermes is currently pending upstream. It is being developed in [NousResearch/hermes-agent PR #5555](https://github.com/NousResearch/hermes-agent/pull/5555) and may change before it lands in a Hermes release.
+The Steel integration for Hermes is currently pending upstream. It is being developed in [NousResearch/hermes-agent PR #5555](https://github.com/NousResearch/hermes-agent/pull/5555) and may change before it lands in a Hermes release. Upvote or comment on the PR to signal interest.
 :::
 
 ### Overview
@@ -14,26 +14,17 @@ The Steel integration for Hermes is currently pending upstream. It is being deve
 The pending Hermes integration adds Steel as a cloud browser provider inside Hermes. Based on the current upstream pull request, the integration is expected to provide:
 
 *   Steel as a selectable browser provider during Hermes setup
-
 *   Steel-backed browser sessions for web navigation and interaction
-
 *   A `steel_scrape` tool for server-side content extraction
-
 *   Support for Steel-specific options such as proxying and CAPTCHA solving
-
 *   Viewer URL support so you can monitor browser sessions while the agent runs
-
 
 If this ships as proposed, Hermes users will be able to route browser tasks through Steel by setting `STEEL_API_KEY` and selecting Steel in Hermes configuration.
 
 ### Requirements
 
 *   **Hermes Agent**: A build that includes the Steel integration from PR #5555 or a future release that ships it
-
 *   **Steel API Key**: Active Steel account
-
-*   **LLM Provider**: Any model supported by Hermes for tool-calling workflows
-
 
 ### Expected setup flow
 
@@ -46,13 +37,10 @@ hermes setup
 During setup:
 
 1.  Choose your model provider
-
-2.  Select Steel as the browser provider if the option is available
-
+2.  Select Steel as the browser provider
 3.  Add your `STEEL_API_KEY`
 
-
-If you are using a current release of Hermes and do not see Steel in the setup flow, that is expected until the integration lands upstream.
+If you are using a current release of Hermes and do not see Steel in the setup flow, that is expected until the integration lands upstream. To try it now, check out the PR branch and run Hermes from source.
 
 ### Expected workflow
 
@@ -64,46 +52,17 @@ Find a hotel near Grand Central and compare the top options.
 
 In the proposed implementation, Hermes would start a Steel session, browse the relevant sites, and return a viewer URL alongside the task output so you can inspect the session while it runs.
 
-The same proposal also adds a `steel_scrape` tool for content extraction when a full browser session is not necessary.
-
-### Current status
-
-At the time of writing, the Steel integration is documented in the open upstream pull request:
-
-*   [NousResearch/hermes-agent PR #5555](https://github.com/NousResearch/hermes-agent/pull/5555)
-
-That PR describes:
-
-*   A `SteelProvider`
-
-*   A `steel_scrape` tool
-
-*   Setup wizard support for selecting Steel
-
-*   Additional Steel-related environment variables and browser hints
-
-
-Until that work merges and ships, treat this page as a preview of the proposed integration rather than a released setup guide.
-
 ### Constraints
 
 *   **This integration is not yet part of a released Hermes build.** Check the upstream PR or Hermes changelog before relying on it.
-
 *   **The setup flow may change before release.** Provider names, environment variables, or supported options may still be updated.
-
 *   **Documentation should be validated against the released Hermes version once the PR lands.**
-
 
 ### Additional Resources
 
 *   [Steel is now a native browser provider in Hermes](https://steel.dev/blog/steel-is-now-a-native-browser-provider-in-hermes) – Blog post covering the Hermes integration
-
 *   [Hermes Agent repository](https://github.com/NousResearch/hermes-agent) – Upstream project
-
 *   [Steel integration PR #5555](https://github.com/NousResearch/hermes-agent/pull/5555) – Proposed Steel provider implementation
-
 *   [Steel CLI docs](/overview/steel-cli) – Steel browser workflows from the terminal
-
 *   [Steel Sessions API Reference](/api-reference) – Programmatic session management
-
 *   [Discord](https://discord.gg/steel-dev) – Get help and share what you build

--- a/content/docs/integrations/coding-agents/hermes-agent.mdx
+++ b/content/docs/integrations/coding-agents/hermes-agent.mdx
@@ -1,0 +1,109 @@
+---
+title: Hermes Agent
+sidebarTitle: Hermes Agent
+description: Hermes Agent has a pending Steel integration that adds Steel as a cloud browser provider. This page tracks the proposed workflow and links to the upstream pull request.
+llm: true
+---
+
+:::callout
+The Steel integration for Hermes is currently pending upstream. It is being developed in [NousResearch/hermes-agent PR #5555](https://github.com/NousResearch/hermes-agent/pull/5555) and may change before it lands in a Hermes release.
+:::
+
+### Overview
+
+The pending Hermes integration adds Steel as a cloud browser provider inside Hermes. Based on the current upstream pull request, the integration is expected to provide:
+
+*   Steel as a selectable browser provider during Hermes setup
+
+*   Steel-backed browser sessions for web navigation and interaction
+
+*   A `steel_scrape` tool for server-side content extraction
+
+*   Support for Steel-specific options such as proxying and CAPTCHA solving
+
+*   Viewer URL support so you can monitor browser sessions while the agent runs
+
+
+If this ships as proposed, Hermes users will be able to route browser tasks through Steel by setting `STEEL_API_KEY` and selecting Steel in Hermes configuration.
+
+### Requirements
+
+*   **Hermes Agent**: A build that includes the Steel integration from PR #5555 or a future release that ships it
+
+*   **Steel API Key**: Active Steel account
+
+*   **LLM Provider**: Any model supported by Hermes for tool-calling workflows
+
+
+### Expected setup flow
+
+The workflow below reflects the current pull request, not a released Hermes build.
+
+```bash Terminal
+hermes setup
+```
+
+During setup:
+
+1.  Choose your model provider
+
+2.  Select Steel as the browser provider if the option is available
+
+3.  Add your `STEEL_API_KEY`
+
+
+If you are using a current release of Hermes and do not see Steel in the setup flow, that is expected until the integration lands upstream.
+
+### Expected workflow
+
+Once the integration is available, Hermes should be able to use Steel for tasks that need a real browser:
+
+```
+Find a hotel near Grand Central and compare the top options.
+```
+
+In the proposed implementation, Hermes would start a Steel session, browse the relevant sites, and return a viewer URL alongside the task output so you can inspect the session while it runs.
+
+The same proposal also adds a `steel_scrape` tool for content extraction when a full browser session is not necessary.
+
+### Current status
+
+At the time of writing, the Steel integration is documented in the open upstream pull request:
+
+*   [NousResearch/hermes-agent PR #5555](https://github.com/NousResearch/hermes-agent/pull/5555)
+
+That PR describes:
+
+*   A `SteelProvider`
+
+*   A `steel_scrape` tool
+
+*   Setup wizard support for selecting Steel
+
+*   Additional Steel-related environment variables and browser hints
+
+
+Until that work merges and ships, treat this page as a preview of the proposed integration rather than a released setup guide.
+
+### Constraints
+
+*   **This integration is not yet part of a released Hermes build.** Check the upstream PR or Hermes changelog before relying on it.
+
+*   **The setup flow may change before release.** Provider names, environment variables, or supported options may still be updated.
+
+*   **Documentation should be validated against the released Hermes version once the PR lands.**
+
+
+### Additional Resources
+
+*   [Steel is now a native browser provider in Hermes](https://steel.dev/blog/steel-is-now-a-native-browser-provider-in-hermes) – Blog post covering the Hermes integration
+
+*   [Hermes Agent repository](https://github.com/NousResearch/hermes-agent) – Upstream project
+
+*   [Steel integration PR #5555](https://github.com/NousResearch/hermes-agent/pull/5555) – Proposed Steel provider implementation
+
+*   [Steel CLI docs](/overview/steel-cli) – Steel browser workflows from the terminal
+
+*   [Steel Sessions API Reference](/api-reference) – Programmatic session management
+
+*   [Discord](https://discord.gg/steel-dev) – Get help and share what you build

--- a/content/docs/integrations/coding-agents/meta.json
+++ b/content/docs/integrations/coding-agents/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Coding Agents",
   "root": false,
-  "pages": ["---Coding Agents---", "codex", "claude-code", "hermes-agent", "openclaw"]
+  "pages": ["---Coding Agents---", "codex", "claude-code", "hermes-agent", "openclaw", "pi-agent"]
 }

--- a/content/docs/integrations/coding-agents/meta.json
+++ b/content/docs/integrations/coding-agents/meta.json
@@ -1,0 +1,5 @@
+{
+  "title": "Coding Agents",
+  "root": false,
+  "pages": ["---Coding Agents---", "codex", "claude-code", "hermes-agent", "openclaw"]
+}

--- a/content/docs/integrations/coding-agents/openclaw.mdx
+++ b/content/docs/integrations/coding-agents/openclaw.mdx
@@ -1,0 +1,123 @@
+---
+title: OpenClaw
+sidebarTitle: OpenClaw
+description: Use OpenClaw with Steel CLI to run real browser sessions, inspect live web state, and automate form-heavy workflows from the terminal.
+llm: true
+---
+
+### Overview
+
+The OpenClaw integration uses Steel CLI as a terminal tool inside OpenClaw. This lets OpenClaw:
+
+*   Start and control Steel browser sessions for multi-step web tasks
+
+*   Use `steel scrape` for rendered page extraction when interaction is not required
+
+*   Monitor live browser state through Steel's session viewer
+
+*   Work through real forms, dynamic pages, and browser-based workflows without writing custom integration code
+
+
+Once Steel CLI is installed and available on `PATH`, OpenClaw can use it like any other terminal tool. That makes it a good fit for tasks like application forms, operational workflows, and browser-driven research.
+
+### Requirements
+
+*   **Node.js**: Version 18 or higher
+
+*   **OpenClaw**: Installed locally
+
+*   **Steel CLI**: Installed locally
+
+*   **Steel API Key**: Active Steel account
+
+
+### Setup
+
+#### Step 1: Install Steel CLI
+
+```bash Terminal
+curl -LsSf https://setup.steel.dev | sh
+```
+
+#### Step 2: Log in
+
+```bash Terminal
+steel login
+```
+
+#### Step 3: Install the browser skill (recommended)
+
+The `steel-browser` skill gives OpenClaw better command discovery and more reliable browser workflows.
+
+```bash Terminal
+npx skills add github:steel-dev/cli/skills/steel-browser
+```
+
+Restart OpenClaw after installing so it can discover the skill.
+
+### Example workflow
+
+OpenClaw works well on browser tasks that need real interaction. One example is filling out a conference CFP form: finding the right page, inspecting the fields, drafting responses, and working through the submission flow.
+
+You can start with a prompt like:
+
+```
+I would like to submit an application for the call for speakers for AI Engineer World's Fair. Could you figure out what the fields are, what we need, and how I can apply to become a speaker?
+```
+
+From there, OpenClaw can start a Steel session, navigate the form, inspect fields with snapshots, and work through the page step by step.
+
+### Watching the session
+
+Steel sessions return a viewer URL so you can watch the browser while the agent works. This is useful on form-heavy flows, especially when the page changes dynamically, a modal blocks progress, or the agent needs a second attempt to recover from a mistake.
+
+For longer workflows, Steel also keeps the full session history so you can inspect what happened after the fact.
+
+### Where OpenClaw works best
+
+OpenClaw is a strong fit for:
+
+*   Standard web forms
+
+*   Multi-step browser workflows
+
+*   Pages that need JavaScript rendering before the agent can reason about them
+
+
+For tasks that only need page content, `steel scrape` is often the faster option:
+
+```bash Terminal
+steel scrape https://example.com
+```
+
+### Authenticated workflows
+
+For sites behind login, it is usually better to prepare reusable auth state in Steel ahead of time rather than asking the agent to log in from scratch every time.
+
+See:
+
+*   [Profiles API](/overview/profiles-api/overview)
+
+*   [Reusing Auth Context](/overview/sessions-api/reusing-auth-context)
+
+
+### Constraints
+
+*   **Command approvals depend on your OpenClaw settings.** Shell access may require approval depending on your configuration.
+
+*   **Form-heavy workflows can still take time.** Dynamic fields, validation errors, and bot checks add retries and extra browser steps.
+
+*   **Authenticated sites work best with prepared Steel auth state.** Reusing profiles or auth context is generally more reliable than repeated interactive logins.
+
+
+### Additional Resources
+
+*   [OpenClaw + Steel blog post](https://steel.dev/blog/openclaw-steel-browser-let-your-ai-agent-fill-the-forms) – Case study using OpenClaw to work through a CFP submission flow
+
+*   [Steel CLI docs](/overview/steel-cli) – Full command reference and workflows
+
+*   [Steel browser skill](https://github.com/steel-dev/cli/tree/main/skills/steel-browser) – Skill package for coding agents
+
+*   [Get a free API key](https://app.steel.dev) – Sign up and start a session
+
+*   [Discord](https://discord.gg/steel-dev) – Get help and share what you build

--- a/content/docs/integrations/coding-agents/pi-agent.mdx
+++ b/content/docs/integrations/coding-agents/pi-agent.mdx
@@ -1,0 +1,94 @@
+---
+title: Pi Agent
+sidebarTitle: Pi Agent
+description: Use Pi with the pi-steel extension to drive real browser sessions, scrape rendered pages, extract structured data, and run computer actions from the terminal.
+llm: true
+---
+
+:::callout
+This integration is part of Steel's experiments effort. Defaults can change without notice, and stability is not guaranteed.
+:::
+
+### Overview
+
+The Pi integration uses Steel as a native Pi extension through the `@steel-experiments/pi-steel` package. This lets Pi:
+
+*   Start and control Steel browser sessions from the Pi session
+*   Scrape fully rendered pages and perform computer-use actions
+*   Extract structured data with a JSON schema instead of parsing markdown
+*   Capture screenshots and PDFs as Pi artifacts
+*   Fill and submit forms, and reuse sessions across prompts
+
+[Pi](https://pi.dev/) is a minimal, extension-first coding agent. It ships with no built-in browser, so capabilities arrive through `pi install`. Steel plugs into that socket and hands Pi a real cloud browser without any Playwright or headless Chromium setup on your side.
+
+### Requirements
+
+*   **Node.js**: Version 18 or higher
+*   **Pi**: Installed locally
+*   **Steel API Key**: Active Steel account
+
+### Setup
+
+#### Step 1: Install the extension
+
+```bash Terminal
+pi install npm:@steel-experiments/pi-steel
+```
+
+Pi picks up the extension on the next run and the Steel browser tools become available automatically.
+
+#### Step 2: Authenticate
+
+Set `STEEL_API_KEY` in your environment.
+
+Grab a free API key at [app.steel.dev](https://app.steel.dev) if you do not have one yet.
+
+### Available tools
+
+Once the extension is installed, Pi has access to a full browser toolset:
+
+*   `steel_navigate` and `steel_scrape` for fetching pages as text, markdown, or HTML
+*   `steel_extract` for structured data from a JSON schema
+*   `steel_fill_form` for submitting forms
+*   Playwright-backed computer actions (click, scroll, type) for pages that scraping cannot reach
+*   Screenshot and PDF capture, returned as Pi artifacts
+*   `steel_pin_session` to keep a browser alive across prompts, or `STEEL_SESSION_MODE=session` for persistent mode
+
+CAPTCHA handling is built in, so most bot-protected pages work without extra configuration.
+
+### Example workflow
+
+Pi works well on research tasks that span multiple pages and require both scraping and interaction. A prompt like:
+
+```
+Visit apple.com and compare all recent MacBook models.
+```
+
+Pi will navigate the Mac lineup, follow links into each model page, and fall back to computer actions and screenshots when sticky navigation or viewport-dependent sections block plain scraping.
+
+For bot-protected docs:
+
+```
+Visit OpenAI docs and tell us how we can use the latest model.
+```
+
+Steel handles the bot-protection layer so Pi sees a normal webpage, reads the current API reference, and returns an up-to-date code example rather than a stale one from training data.
+
+### Structured extraction
+
+When you would otherwise parse markdown for prices, specs, or listings, `steel_extract` with a JSON schema is usually the better call. Pi gets typed output directly, which is easier to reason about across multi-step workflows.
+
+### Constraints
+
+*   **Command approvals depend on your Pi settings.** Extension tools may require approval depending on your configuration.
+*   **First runs are usually the roughest.** Dynamic web apps often need a few retries before the workflow is stable.
+*   **Authenticated sites work best with prepared Steel auth state.** Reusing profiles or auth context is generally more reliable than repeated interactive logins.
+
+### Additional Resources
+
+*   [pi-steel: we gave Pi a real browser in one command](https://steel.dev/blog/pi-agent-steel-browser) – Blog post on the extension and example runs
+*   [`@steel-experiments/pi-steel` on GitHub](https://github.com/steel-experiments/pi-steel) – Source and issues
+*   [`@steel-experiments/pi-steel` on npm](https://www.npmjs.com/package/@steel-experiments/pi-steel) – Package page
+*   [Steel CLI docs](/overview/steel-cli) – Full command reference and workflows
+*   [Get a free API key](https://app.steel.dev) – Sign up and start a session
+*   [Discord](https://discord.gg/steel-dev) – Get help and share what you build

--- a/content/docs/integrations/gemini-computer-use/overview.mdx
+++ b/content/docs/integrations/gemini-computer-use/overview.mdx
@@ -2,7 +2,7 @@
 title: Overview
 sidebarTitle: Overview
 description: Gemini's Computer Use is an agent that combines vision capabilities with advanced reasoning to control computer interfaces and perform tasks on behalf of users through a continuous action loop.
-llm: false
+llm: true
 ---
 ### Overview
 

--- a/content/docs/integrations/meta.json
+++ b/content/docs/integrations/meta.json
@@ -2,6 +2,7 @@
   "title": "Integrations",
   "root": true,
   "pages": [
+    "...coding-agents",
     "...agentkit",
     "...agno",
     "...browser-use",

--- a/content/docs/integrations/openai-computer-use/overview.mdx
+++ b/content/docs/integrations/openai-computer-use/overview.mdx
@@ -2,7 +2,7 @@
 title: Overview
 sidebarTitle: Overview
 description: OpenAI's Computer Use is an agent that combines vision capabilities with advanced reasoning to control computer interfaces and perform tasks on behalf of users through a continuous action loop.
-llm: false
+llm: true
 ---
 ### Overview
 

--- a/content/docs/integrations/stagehand/overview.mdx
+++ b/content/docs/integrations/stagehand/overview.mdx
@@ -2,7 +2,7 @@
 title: Overview
 sidebarTitle: Overview
 description: Stagehand is an open-source library that allows you to write browser automations in natural language. This integration connects Stagehand with Steel's infrastructure, allowing for seamless automation of web tasks and workflows in the cloud.
-llm: false
+llm: true
 ---
 ### Requirements & Limitations
 

--- a/content/docs/integrations/valtown/overview.mdx
+++ b/content/docs/integrations/valtown/overview.mdx
@@ -2,7 +2,7 @@
 title: Overview
 sidebarTitle: Overview
 description: Val Town is a collaborative platform for writing and deploying TypeScript functions, enabling you to build APIs and schedule tasks directly from your browser.
-llm: false
+llm: true
 ---
 ### Overview
 

--- a/content/docs/integrations/x402/meta.json
+++ b/content/docs/integrations/x402/meta.json
@@ -1,0 +1,5 @@
+{
+  "title": "x402",
+  "root": false,
+  "pages": ["---x402---", "overview"]
+}

--- a/content/docs/integrations/x402/overview.mdx
+++ b/content/docs/integrations/x402/overview.mdx
@@ -1,0 +1,42 @@
+---
+title: Overview
+sidebarTitle: Overview
+description: Pay-per-use browser sessions with USDC on Base and Solana. No API key needed.
+llm: true
+---
+### Overview
+
+The x402 Integration enables pay-per-use browser sessions powered by cryptocurrency. Built on the x402 protocol, it lets you create and manage Steel sessions by paying with USDC on Base or Solana, with no API keys or accounts required.
+
+Endpoint: https://x402.steel.dev
+
+### How It Works
+
+*   **Step 1: Send Request**: Make a request to the x402 endpoint. The server responds with a 402 Payment Required.
+
+*   **Step 2: Sign Transaction**: Your client constructs and signs a payment authorization via a wallet for the requested amount.
+
+*   **Step 3: Pay & Get Data **: Resend the request with the signed payment header and receive your data with a 200 OK response.
+
+### Pricing
+
+Rate: $0.10/hour
+
+### Requirements
+
+*   **Wallet**: Base or Solana wallet with USDC.
+
+### Supported Tokens and Networks
+
+| Network                | USDC Contract Address                             |
+|------------------------|---------------------------------------------------|
+| Base (mainnet)         | **0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913**    |
+| Solana (mainnet)       | **EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v**  |
+
+### Additional Resources
+
+*   [x402 Protocol](https://www.x402.org/) - Learn more about the x402 protocol.
+
+*   [Steel Sessions API Reference](/api-reference) - Technical details for managing Steel browser sessions
+
+*   [Community Discord](https://discord.gg/steel-dev) - Get help and share your implementations

--- a/content/docs/overview/sessions-api/embed-sessions/index.mdx
+++ b/content/docs/overview/sessions-api/embed-sessions/index.mdx
@@ -2,7 +2,7 @@
 title: Embed Sessions
 sidebarTitle: Embed Sessions
 description: Learn how to view and embed your live and past sessions.
-llm: false
+llm: true
 ---
 
 You can embed Steel sessions directly into your applications or dashboards to watch live browser activity or replay recorded sessions.

--- a/content/docs/overview/sessions-api/embed-sessions/live-sessions.mdx
+++ b/content/docs/overview/sessions-api/embed-sessions/live-sessions.mdx
@@ -2,7 +2,7 @@
 title: Live Sessions
 sidebarTitle: Live Sessions
 description: How to embed and share live browser sessions in your applications
-llm: false
+llm: true
 ---
 
 Steel sessions can be viewed live directly from your app or dashboard.  

--- a/content/docs/overview/sessions-api/embed-sessions/past-sessions.mdx
+++ b/content/docs/overview/sessions-api/embed-sessions/past-sessions.mdx
@@ -2,7 +2,7 @@
 title: Past Sessions
 sidebarTitle: Past Sessions
 description: How to access recordings of past browser sessions and display them within your app
-llm: false
+llm: true
 ---
 
 Steel automatically records every session so you can replay it later.  

--- a/content/docs/overview/sessions-api/mobile-mode.mdx
+++ b/content/docs/overview/sessions-api/mobile-mode.mdx
@@ -2,7 +2,7 @@
 title: Mobile Mode
 sidebarTitle: Mobile Mode
 description: Create browser sessions that appear as mobile devices with full mobile fingerprints and touch capabilities.
-llm: false
+llm: true
 ---
 
 ### Overview

--- a/content/docs/overview/sessions-api/multi-region.mdx
+++ b/content/docs/overview/sessions-api/multi-region.mdx
@@ -2,7 +2,7 @@
 title: Multi-region
 sidebarTitle: Multi-region
 description: Control where your Steel browser sessions are hosted for optimal performance and latency.
-llm: false
+llm: true
 ---
 ### Overview
 

--- a/content/docs/overview/sessions-api/overview.mdx
+++ b/content/docs/overview/sessions-api/overview.mdx
@@ -2,7 +2,7 @@
 title: Overview
 sidebarTitle: Overview
 description: The Sessions API lets you create and control cloud-based browser sessions through simple API calls. Each session is like a fresh incognito window, but running in our cloud and controlled through code.
-llm: false
+llm: true
 ---
 
 [Go to Quickstart Example](/overview/sessions-api/quickstart)

--- a/content/docs/overview/sessions-api/session-lifecycle.mdx
+++ b/content/docs/overview/sessions-api/session-lifecycle.mdx
@@ -2,7 +2,7 @@
 title: Session Lifecycle
 sidebarTitle: Session Lifecycle
 description: Learn how to start and release browser sessions programatically.
-llm: false
+llm: true
 ---
 
 ### Overview


### PR DESCRIPTION
## What changed

Adds a new `Coding Agents` section under `Integrations` and documents five agent-specific pages:

- `Codex`
- `Claude Code`
- `Hermes Agent`
- `OpenClaw`
- section `meta.json`

The new pages follow the existing integrations-docs structure with:

- overview and use cases
- requirements
- setup steps
- example workflows
- constraints
- resource links

The Hermes page is intentionally marked as pending upstream and links to the Hermes PR rather than presenting the integration as already released.

## Why

These docs add a dedicated place for coding-agent integrations and align the new pages with the current docs tone and structure instead of leaving them as blog-style drafts.

## User impact

Users browsing `/integrations` will now see a `Coding Agents` section with pages for the supported and in-progress agent workflows.

## Validation

- `bun run check`
- `bun run validate-links`
- `bun run build`

## Notes

- Left the unrelated local `next-env.d.ts` change out of this PR on purpose.
- Build succeeds, with existing Code Hike warnings for unknown code block languages still present in the repo.
