### PR TITLE
docs: draft changelog #022

### DIFF
--- a/content/docs/changelog/changelog-022.mdx
+++ b/content/docs/changelog/changelog-022.mdx
@@ -1,0 +1,46 @@
+---
+title: "Changelog #022"
+sidebarTitle: "Changelog #022"
+llm: true
+image: "/images/changelog-placeholder-white.jpeg"
+imageAlt: "White placeholder image for changelog drafts"
+imageWidth: 400
+imageHeight: 300
+---
+import Image from 'next/image';
+
+<Image
+  src="/images/changelog-placeholder-white.jpeg"
+  alt="White placeholder image for changelog drafts"
+  width={400}
+  height={300}
+/>
+Hey everyone — this week we focused on agent onboarding, broader coding-agent support in the CLI, and a handful of reliability and platform updates behind the scenes.
+
+### ⭐ New
+
+#### Coding agent integrations
+
+Steel CLI now supports Codex, OpenCode, and Pi coding agent workflows, with updated integration docs covering agent setup and usage.
+
+### 🐛 Bug Fixes
+
+*   Fixed session metering so billed duration is clamped to the configured timeout.
+
+*   Fixed the `forge` command in Steel CLI.
+
+### 🔧 Improvements
+
+*   Updated Steel Cloud onboarding with a more agent-native setup flow and refreshed first-run guidance.
+
+*   Steel CLI now simplifies `--agent` mode and always prints the agent guide when that mode is used.
+
+*   Expanded docs and cookbook examples for computer-use and agent workflows, and enabled more Sessions API and integrations pages for LLM-friendly markdown sharing.
+
+*   Improved browser infrastructure reliability with updated fleet-controller probe and resource tuning, browser VM density changes, and additional monitoring coverage.
+
+*   Added support for additional proxy provider secrets in infrastructure configuration.
+
+### 🏡 Housekeeping
+
+*   Added `llms.steel.dev` infrastructure and related DNS configuration.

--- a/content/docs/changelog/meta.json
+++ b/content/docs/changelog/meta.json
@@ -3,6 +3,7 @@
   "root": true,
   "pages": [
     "---Changelog---",
+    "changelog-022",
     "changelog-021",
     "changelog-020",
     "changelog-019",


### PR DESCRIPTION
# docs: draft changelog #022

Generated `content/docs/changelog/changelog-022.mdx`.

- Window: `2026-04-14T00:00:00.000Z` to `2026-04-23T00:00:00.000Z`
- Window source: `manual`
- Timezone reference: `America/Toronto`
- The MDX draft is intentionally clean. Commit references for kept items are listed below for review.
- Placeholder image: `/images/changelog-placeholder-white.jpeg`

## Monitored repositories

- `steel-dev/steel-browser@main`
- `0xnenlabs/steel@release`
- `steel-dev/infra@main`
- `steel-dev/surf.new@main`
- `steel-dev/steel-cookbook@main`
- `steel-dev/steel-mcp-server@main`
- `steel-dev/leaderboard@main`
- `steel-dev/awesome-web-agents@main`
- `steel-dev/cli@main`
- `steel-dev/docs@main`

## Included items

### ⭐ New

- **Coding agent integrations**: Steel CLI now supports Codex, OpenCode, and Pi coding agent workflows, with updated integration docs covering agent setup and usage. [steel-dev/cli f6f304b](https://github.com/steel-dev/cli/commit/f6f304b06ec98c7c9ef1832d1bb2e5a861618d4a) [steel-dev/cli 4c36584](https://github.com/steel-dev/cli/commit/4c365844b713ae22fb8ad27ab17f31f78330af50) [steel-dev/docs 75bcdc9](https://github.com/steel-dev/docs/commit/75bcdc9c80c6344b58790b06c883adc2ef7d59ee)

### 🐛 Bug Fixes

- Fixed session metering so billed duration is clamped to the configured timeout. [0xnenlabs/steel 27a56f4](https://github.com/0xnenlabs/steel/commit/27a56f4a308539e74b5819c0b8b8a515e4747039)
- Fixed the `forge` command in Steel CLI. [steel-dev/cli c046eca](https://github.com/steel-dev/cli/commit/c046ecac51960212d66cc7d63d1b4d1a09b79eae)

### 🔧 Improvements

- Updated Steel Cloud onboarding with a more agent-native setup flow and refreshed first-run guidance. [0xnenlabs/steel 91a794b](https://github.com/0xnenlabs/steel/commit/91a794bcc32756869ed2b8836bc07985b3c3d172)
- Steel CLI now simplifies `--agent` mode and always prints the agent guide when that mode is used. [steel-dev/cli 5c93d80](https://github.com/steel-dev/cli/commit/5c93d8029955fddce73a6e8c7581dc7b928fd8d2) [steel-dev/cli 140692b](https://github.com/steel-dev/cli/commit/140692b548aaf182c1508d22d21601b0745af7ba)
- Expanded docs and cookbook examples for computer-use and agent workflows, and enabled more Sessions API and integrations pages for LLM-friendly markdown sharing. [steel-dev/docs aa0ce4e](https://github.com/steel-dev/docs/commit/aa0ce4e3fefe8f6ab3c16c319a51d58c16de6c01) [steel-dev/docs 9d193ea](https://github.com/steel-dev/docs/commit/9d193ea1d73a560928762f0fc351c830af8f8c93) [steel-dev/docs 75bcdc9](https://github.com/steel-dev/docs/commit/75bcdc9c80c6344b58790b06c883adc2ef7d59ee) [steel-dev/steel-cookbook d38c0b9](https://github.com/steel-dev/steel-cookbook/commit/d38c0b9cf1d156549a73c0fbdfecc62ccab8f09b) [steel-dev/steel-cookbook 93080cd](https://github.com/steel-dev/steel-cookbook/commit/93080cd0730088de2acd9bd2504f18857f2bf753) [steel-dev/steel-cookbook a741351](https://github.com/steel-dev/steel-cookbook/commit/a741351c86b5ef49cc3c1862b68b52c391f7a339)
- Improved browser infrastructure reliability with updated fleet-controller probe and resource tuning, browser VM density changes, and additional monitoring coverage. [steel-dev/infra 7568414](https://github.com/steel-dev/infra/commit/7568414ca1d2c892005360d2ac69bd552e410ad0) [steel-dev/infra 47a551e](https://github.com/steel-dev/infra/commit/47a551e648efc40e89fece19b2a01a25fec474dd) [steel-dev/infra 3a11e23](https://github.com/steel-dev/infra/commit/3a11e23e629be3636cf2aebb8080d30ca76b1aed) [steel-dev/infra 670c9de](https://github.com/steel-dev/infra/commit/670c9de3eca6b03d51beb6d877225ea46bcf3d95)
- Added support for additional proxy provider secrets in infrastructure configuration. [steel-dev/infra 064efa8](https://github.com/steel-dev/infra/commit/064efa81bb236cbc73d8578be1dbaec87870167b)

### 🏡 Housekeeping

- Added `llms.steel.dev` infrastructure and related DNS configuration. [steel-dev/infra 70ffbae](https://github.com/steel-dev/infra/commit/70ffbaef35f0848e9964ca482c073b0b0ec3761d) [steel-dev/infra 7c68fb0](https://github.com/steel-dev/infra/commit/7c68fb01c18d22c21e6657068cd5ba2ae9ac7835) [steel-dev/infra 44fa808](https://github.com/steel-dev/infra/commit/44fa8081e1cbb57e6fa7e38fd46dff15da55402a)

## Discarded items

- Added Not Human Search and ClawBench to awesome-web-agents. — Useful ecosystem curation, but not a direct Steel product change. [steel-dev/awesome-web-agents 055ca55](https://github.com/steel-dev/awesome-web-agents/commit/055ca55e3ff11ff4a70dab52f402b8c7d7058b49) [steel-dev/awesome-web-agents 3bbec99](https://github.com/steel-dev/awesome-web-agents/commit/3bbec99a22449487e835054d1587a357e201988f)
- Admin console polish for internal organization, session, Clerk, and Stripe navigation. — Mostly internal ops tooling improvements rather than broadly user-facing product changes. [0xnenlabs/steel efe9b55](https://github.com/0xnenlabs/steel/commit/efe9b5540ddb8da5c9d22abfd372359a9b378f4b)
- Typed interface additions in steel-browser. — Internal type-safety work with no clear end-user behavior change. [steel-dev/steel-browser e541bab](https://github.com/steel-dev/steel-browser/commit/e541bab367b7a69a6d861a708d1424eee6107f2f)
- Dependency bumps, stale ref cleanup, install command canonicalization, and security package updates across CLI and docs. — Routine maintenance unless tied to a clearer user-facing workflow change. [steel-dev/cli 451d32c](https://github.com/steel-dev/cli/commit/451d32c54d988e6f52a1b736fe56c94735cac48a) [steel-dev/cli 8dcfba7](https://github.com/steel-dev/cli/commit/8dcfba7b17d6fbdbbcae7c997e869a2ba9782978) [steel-dev/cli bd93d30](https://github.com/steel-dev/cli/commit/bd93d308a1f5e380fd992aa8026bea509726e046) [steel-dev/cli 1b45f6b](https://github.com/steel-dev/cli/commit/1b45f6b0e4d5ef7360f8faa59072edab79716aca) [steel-dev/docs 7f8df60](https://github.com/steel-dev/docs/commit/7f8df60148b7587134a34a0f923a1874a17f0b11) [steel-dev/docs 4df2707](https://github.com/steel-dev/docs/commit/4df27074dbbe4c33de5e53bc7fdd773f102acc1c)
- Automatic image rollouts, secret rotations, rollout percentage changes, and other repetitive infra config churn. — Too operational and noisy for the changelog without a clearer user-visible outcome. [steel-dev/infra ff33b35](https://github.com/steel-dev/infra/commit/ff33b354fc5597dcd0458bab84c94a9b9ae45024) [steel-dev/infra 511def6](https://github.com/steel-dev/infra/commit/511def6e4e0a1b0be0e77eed2f7e46f4d7d0da9e) [steel-dev/infra 9129269](https://github.com/steel-dev/infra/commit/91292693ab8d0a9671f4d448d847bf7174af4b2e) [steel-dev/infra 63cbe69](https://github.com/steel-dev/infra/commit/63cbe69cb4e1a2f7d6eca5b6ec0409f1740caabb) [steel-dev/infra 4f3d496](https://github.com/steel-dev/infra/commit/4f3d49630dc03850912ce425647de0ef0ba070ed)
