### PR TITLE
docs: add Agent Traces section (overview, timeline & exports, API)

### DIFF
--- a/content/docs/overview/agent-traces/api.mdx
+++ b/content/docs/overview/agent-traces/api.mdx
@@ -1,0 +1,140 @@
+---
+title: Agent Traces API
+sidebarTitle: API
+description: Fetch the semantic timeline of any session as JSON, or subscribe to live activities over a WebSocket as the agent runs.
+llm: true
+publishedAt: "2026-05-22"
+---
+
+Agent Traces are available over the same API as the rest of Steel. Two authenticated endpoints plus a WebSocket channel.
+
+| Endpoint | Purpose |
+| -------- | ------- |
+| `GET /v1/sessions/:id/agent-traces` | **Use this one.** Semantic timeline with selectors, target labels, and bounding boxes. |
+| `GET /v1/sessions/:id/agent-logs` | Backward-compatible. Raw CDP-derived events (coordinates, key codes, URLs). Lower-level. |
+| `WS /v1/sessions/:id/agent-traces/stream` | Live stream of new activities while a session is running. |
+
+### GET /v1/sessions/:id/agent-traces
+
+Returns the full semantic timeline for a finished or in-progress session. For sessions recorded before semantic capture existed the endpoint returns an empty `events` array — fall back to `/agent-logs` only if you specifically need to support legacy sessions.
+
+```bash !! curl -wcn
+curl https://api.steel.dev/v1/sessions/$SESSION_ID/agent-traces \
+  -H "steel-api-key: $STEEL_API_KEY"
+```
+
+```javascript !! fetch -wcn
+const response = await fetch(
+  `https://api.steel.dev/v1/sessions/${sessionId}/agent-traces`,
+  { headers: { "steel-api-key": process.env.STEEL_API_KEY } },
+);
+
+const { events, total, hasMore } = await response.json();
+```
+
+#### Response shape
+
+```json !! JSON -wcn
+{
+  "events": [ /* AgentActivity[] */ ],
+  "total": 42,
+  "hasMore": false
+}
+```
+
+Each `AgentActivity` shares a common envelope:
+
+| Field | Type | Notes |
+| ----- | ---- | ----- |
+| `type` | `"click" \| "input" \| "navigate" \| "scroll" \| "drag" \| "keyPress" \| "submit" \| "error"` | The verb shown in the timeline. |
+| `timestamp` | ISO 8601 string | Wall clock when the activity happened. |
+| `offsetMs` | number | Milliseconds from session start. Used for video sync. |
+| `url` | string | Page URL at the moment of the activity. |
+| `target` | object | Element metadata (see below). Absent on `navigate`. |
+| `duration` | number | Present on coalesced runs (typing bursts, rapid clicks). Milliseconds. |
+| `raw` | object | The underlying browser event. Shape varies by `type`. |
+
+The `target` object is the human-readable layer the UI displays:
+
+```json !! target -wcn
+{
+  "label": "Sign in",
+  "tag": "button",
+  "role": "button",
+  "accessibleName": "Sign in",
+  "boundingBox": { "x": 504, "y": 392, "width": 96, "height": 36 },
+  "attributes": {
+    "data-testid": "sign-in",
+    "type": "submit",
+    "class": "btn btn-primary"
+  },
+  "selectors": {
+    "testId": "[data-testid=sign-in]",
+    "id": null,
+    "aria": "[aria-label='Sign in']",
+    "name": null,
+    "css": "button[data-testid=sign-in]",
+    "xpath": "//button[@data-testid='sign-in']"
+  }
+}
+```
+
+Selectors are listed in priority order — `testId → id → aria → name → CSS → XPath`. The first non-null value is the canonical selector Steel uses internally.
+
+#### Per-type fields
+
+A handful of activity types carry extra fields beyond the common envelope.
+
+| Type | Extra fields |
+| ---- | ------------ |
+| `click`, `drag` | `x`, `y`, `button`, `clickCount`, `modifiers` |
+| `input` | `length` (number of characters), `redacted` (boolean), `value` (omitted if redacted) |
+| `keyPress` | `key`, `code`, `modifiers` |
+| `navigate` | `fromUrl`, `toUrl`, `reloaded` (boolean) |
+| `scroll` | `deltaX`, `deltaY`, `scrollTop` |
+| `submit` | `formSelectors`, `fields` (array of `{ name, length, redacted }`) |
+| `error` | `message`, `stack`, `source` (`"page" \| "browser"`) |
+
+### Live stream over WebSocket
+
+Subscribe to new activities as they happen.
+
+```javascript !! fetch -wcn
+const ws = new WebSocket(
+  `wss://api.steel.dev/v1/sessions/${sessionId}/agent-traces/stream`,
+  ["steel-api-key", process.env.STEEL_API_KEY],
+);
+
+ws.addEventListener("message", (event) => {
+  const activity = JSON.parse(event.data);
+  console.log(activity.type, activity.target?.label);
+});
+```
+
+Each message is one `AgentActivity` in the same shape as the REST response. New activities arrive incrementally and may supersede earlier ones — for example a second click within 500ms of the first arrives as a `double-click` that replaces both rows in the dashboard. If you're rendering your own UI, deduplicate on `(timestamp, type, target.selectors.css)` and re-collapse on receipt.
+
+When the session ends the socket closes. The same activities are then available statically from the REST endpoint.
+
+### Backwards compatibility: /agent-logs
+
+`GET /v1/sessions/:id/agent-logs` returns raw CDP-derived events — coordinates, key codes, URLs — without semantic enrichment. It exists for legacy sessions recorded before semantic capture existed, and for callers that want the lower-level signal. New integrations should use `/agent-traces`.
+
+```bash !! curl -wcn
+curl https://api.steel.dev/v1/sessions/$SESSION_ID/agent-logs \
+  -H "steel-api-key: $STEEL_API_KEY"
+```
+
+### Errors
+
+| Status | Meaning |
+| ------ | ------- |
+| 401 | Missing or invalid `steel-api-key`. |
+| 403 | The session belongs to a different organization. |
+| 404 | No session with that ID. |
+| 429 | Rate limit hit. Retry after the `Retry-After` header. |
+
+:::callout
+type: help
+### Need help with the Agent Traces API?
+Reach out on the <span className="font-bold">#help</span> channel on [Discord](https://discord.gg/steel-dev) under the ⭐ community section.
+:::

--- a/content/docs/overview/agent-traces/api.mdx
+++ b/content/docs/overview/agent-traces/api.mdx
@@ -6,17 +6,17 @@ llm: true
 publishedAt: "2026-05-22"
 ---
 
-Agent Traces are available over the same API as the rest of Steel. Two authenticated endpoints plus a WebSocket channel.
+Agent Traces are available over the same API as the rest of Steel: two authenticated endpoints plus a WebSocket channel.
 
 | Endpoint | Purpose |
 | -------- | ------- |
 | `GET /v1/sessions/:id/agent-traces` | **Use this one.** Semantic timeline with selectors, target labels, and bounding boxes. |
-| `GET /v1/sessions/:id/agent-logs` | Backward-compatible. Raw CDP-derived events (coordinates, key codes, URLs). Lower-level. |
+| `GET /v1/sessions/:id/agent-logs` | Backward compatible. Raw CDP-derived events (coordinates, key codes, URLs). Lower level. |
 | `WS /v1/sessions/:id/agent-traces/stream` | Live stream of new activities while a session is running. |
 
 ### GET /v1/sessions/:id/agent-traces
 
-Returns the full semantic timeline for a finished or in-progress session. For sessions recorded before semantic capture existed the endpoint returns an empty `events` array — fall back to `/agent-logs` only if you specifically need to support legacy sessions.
+Returns the full semantic timeline for a finished or in-progress session. For sessions recorded before semantic capture existed the endpoint returns an empty `events` array. Fall back to `/agent-logs` only if you need to support legacy sessions.
 
 ```bash !! curl -wcn
 curl https://api.steel.dev/v1/sessions/$SESSION_ID/agent-traces \
@@ -79,7 +79,7 @@ The `target` object is the human-readable layer the UI displays:
 }
 ```
 
-Selectors are listed in priority order — `testId → id → aria → name → CSS → XPath`. The first non-null value is the canonical selector Steel uses internally.
+Selectors are listed in priority order: `testId`, `id`, `aria`, `name`, `CSS`, `XPath`. The first non-null value is the canonical selector Steel uses internally.
 
 #### Per-type fields
 
@@ -111,13 +111,13 @@ ws.addEventListener("message", (event) => {
 });
 ```
 
-Each message is one `AgentActivity` in the same shape as the REST response. New activities arrive incrementally and may supersede earlier ones — for example a second click within 500ms of the first arrives as a `double-click` that replaces both rows in the dashboard. If you're rendering your own UI, deduplicate on `(timestamp, type, target.selectors.css)` and re-collapse on receipt.
+Each message is one `AgentActivity` in the same shape as the REST response. New activities arrive incrementally and may supersede earlier ones. For example, a second click within 500ms of the first arrives as a `double-click` that replaces both rows in the dashboard. If you're rendering your own UI, deduplicate on `(timestamp, type, target.selectors.css)` and re-collapse on receipt.
 
 When the session ends the socket closes. The same activities are then available statically from the REST endpoint.
 
-### Backwards compatibility: /agent-logs
+### Legacy endpoint: /agent-logs
 
-`GET /v1/sessions/:id/agent-logs` returns raw CDP-derived events — coordinates, key codes, URLs — without semantic enrichment. It exists for legacy sessions recorded before semantic capture existed, and for callers that want the lower-level signal. New integrations should use `/agent-traces`.
+`GET /v1/sessions/:id/agent-logs` returns raw CDP-derived events (coordinates, key codes, URLs) without semantic enrichment. It exists for legacy sessions recorded before semantic capture existed, and for callers that want the lower-level signal. New integrations should use `/agent-traces`.
 
 ```bash !! curl -wcn
 curl https://api.steel.dev/v1/sessions/$SESSION_ID/agent-logs \

--- a/content/docs/overview/agent-traces/api.mdx
+++ b/content/docs/overview/agent-traces/api.mdx
@@ -1,22 +1,16 @@
 ---
 title: Agent Traces API
 sidebarTitle: API
-description: Fetch the semantic timeline of any session as JSON, or subscribe to live activities over a WebSocket as the agent runs.
+description: Fetch the activity timeline for a Steel browser session as JSON.
 llm: true
 publishedAt: "2026-05-22"
 ---
 
-Agent Traces are available over the same API as the rest of Steel: two authenticated endpoints plus a WebSocket channel.
-
-| Endpoint | Purpose |
-| -------- | ------- |
-| `GET /v1/sessions/:id/agent-traces` | **Use this one.** Semantic timeline with selectors, target labels, and bounding boxes. |
-| `GET /v1/sessions/:id/agent-logs` | Backward compatible. Raw CDP-derived events (coordinates, key codes, URLs). Lower level. |
-| `WS /v1/sessions/:id/agent-traces` | Live stream of new activities while a session is running. |
+Use the Agent Traces API when you want the same activity timeline shown in the dashboard, but as JSON for analysis, replay, or internal tooling.
 
 ### GET /v1/sessions/:id/agent-traces
 
-Returns the full semantic timeline for a finished or in-progress session. For sessions recorded before semantic capture existed, the endpoint falls back to CDP-derived activities when available. Those fallback rows are useful for timing and coarse replay, but may not include target metadata like selectors, accessible names, or bounding boxes.
+Returns the trace timeline for a finished or in-progress session.
 
 ```bash !! curl -wcn
 curl https://api.steel.dev/v1/sessions/$SESSION_ID/agent-traces \
@@ -29,93 +23,83 @@ const response = await fetch(
   { headers: { "steel-api-key": process.env.STEEL_API_KEY } },
 );
 
-const { events, total, hasMore } = await response.json();
+const trace = await response.json();
 ```
 
-#### Response shape
+### Response
 
 ```json !! JSON -wcn
 {
-  "events": [ /* AgentActivity[] */ ],
-  "total": 42,
+  "events": [
+    {
+      "type": "click",
+      "timestamp": "2026-05-22T18:03:21.345Z",
+      "page": { "url": "https://example.com/login" },
+      "target": {
+        "role": "button",
+        "accessibleName": "Sign in",
+        "selector": { "css": "button[data-testid=sign-in]" }
+      },
+      "pointer": { "x": 520, "y": 410 }
+    }
+  ],
+  "total": 1,
   "hasMore": false
 }
 ```
 
-Each `AgentActivity` shares a common envelope:
+| Field | Type | Notes |
+| ----- | ---- | ----- |
+| `events` | array | Timeline activities in chronological order. |
+| `total` | number | Number of activities returned. |
+| `hasMore` | boolean | Whether more activity data is available. |
+
+Each activity includes a small common envelope:
 
 | Field | Type | Notes |
 | ----- | ---- | ----- |
-| `type` | string | One of `click`, `doubleClick`, `input`, `change`, `navigate`, `scroll`, `drag`, `keyPress`, `submit`, or `error`. |
-| `timestamp` | ISO 8601 string | Wall clock when the activity happened. |
-| `endTimestamp` | ISO 8601 string | Present on some coalesced runs, such as typing bursts or drags. |
-| `page` | object | Usually `{ url }`, when the page URL is known for the activity. |
-| `target` | object | Element metadata (see below). Absent on `navigate` and some fallback rows. |
+| `type` | string | Activity type, such as `click`, `input`, `navigate`, `scroll`, `drag`, or `error`. |
+| `timestamp` | ISO 8601 string | When the activity happened. |
+| `endTimestamp` | ISO 8601 string | Present when the activity spans a range of time. |
+| `page` | object | Page context, usually including `url`. |
+| `target` | object | Element context when available. |
 
-The `target` object is the human-readable layer the UI displays:
+Activity-specific details appear when relevant. For example, click activities can include `pointer`, typing activities can include `value`, keyboard activities can include `keyboard`, navigation activities can include `navigation`, and error activities can include `error`.
+
+### Target Details
+
+When Steel can identify the element involved in an activity, `target` can include readable labels and useful selectors:
 
 ```json !! target -wcn
 {
-  "tagName": "button",
   "role": "button",
   "accessibleName": "Sign in",
   "text": "Sign in",
-  "boundingBox": { "x": 504, "y": 392, "width": 96, "height": 36 },
   "attributes": {
     "data-testid": "sign-in",
-    "type": "submit",
-    "class": "btn btn-primary"
+    "type": "submit"
   },
   "selector": {
-    "css": "button[data-testid=sign-in]",
-    "xpath": "//button[@data-testid='sign-in']"
+    "css": "button[data-testid=sign-in]"
   }
 }
 ```
 
-Use `target.selector.css` first when it is present. `target.selector.xpath` is included as a fallback, and stable attributes such as `data-testid`, `id`, `name`, `href`, and `aria-*` are available under `target.attributes`.
+Use target details as hints for review or replay. Some activities, such as navigation or errors, may not include a target.
 
-#### Per-type fields
+### Filtering by Time
 
-A handful of activity types carry extra fields beyond the common envelope.
-
-| Type | Extra fields |
-| ---- | ------------ |
-| `click`, `doubleClick` | `pointer` with `x`, `y`, `button`, and `clickCount` |
-| `input`, `change` | `value` with `inputType`, `valueLength`, `text`, `redacted`, and `checked` when relevant |
-| `keyPress` | `keyboard` with `key`, `code`, and `text` |
-| `navigate` | `navigation` with `url` |
-| `scroll` | `pointer` with `x` and `y`, plus `delta` with `x` and `y` when available |
-| `drag` | `pointer` with `startX`, `startY`, `endX`, `endY`, and `button`, plus optional `endTarget` |
-| `error` | `error` with `kind` (`"page" \| "browser" \| "request" \| "other"`), `message`, `stack`, and `url` |
-
-### Live stream over WebSocket
-
-Subscribe to new activities as they happen.
-
-```javascript !! fetch -wcn
-const ws = new WebSocket(
-  `wss://api.steel.dev/v1/sessions/${sessionId}/agent-traces?token=${authToken}`,
-);
-
-ws.addEventListener("message", (event) => {
-  const activity = JSON.parse(event.data);
-  console.log(activity.type, activity.target?.label);
-});
-```
-
-Each message contains new log rows from the live session stream. The dashboard converts browser-interaction rows into `AgentActivity` objects and collapses them client-side. For example, a second click within 500ms of the first may become a `doubleClick` activity. If you're rendering your own UI, normalize incoming rows and merge them with the existing timeline before rendering.
-
-When the session ends the socket closes. The same activities are then available statically from the REST endpoint.
-
-### Legacy endpoint: /agent-logs
-
-`GET /v1/sessions/:id/agent-logs` returns raw CDP-derived events (coordinates, key codes, URLs) without semantic enrichment. It exists for legacy sessions recorded before semantic capture existed, and for callers that want the lower-level signal. New integrations should use `/agent-traces`.
+You can limit results to a time range:
 
 ```bash !! curl -wcn
-curl https://api.steel.dev/v1/sessions/$SESSION_ID/agent-logs \
+curl "https://api.steel.dev/v1/sessions/$SESSION_ID/agent-traces?startTime=2026-05-22T18:00:00.000Z&endTime=2026-05-22T18:10:00.000Z" \
   -H "steel-api-key: $STEEL_API_KEY"
 ```
+
+| Query param | Notes |
+| ----------- | ----- |
+| `startTime` | Include activities at or after this ISO timestamp. |
+| `endTime` | Include activities at or before this ISO timestamp. |
 
 ### Errors
 

--- a/content/docs/overview/agent-traces/api.mdx
+++ b/content/docs/overview/agent-traces/api.mdx
@@ -12,11 +12,11 @@ Agent Traces are available over the same API as the rest of Steel: two authentic
 | -------- | ------- |
 | `GET /v1/sessions/:id/agent-traces` | **Use this one.** Semantic timeline with selectors, target labels, and bounding boxes. |
 | `GET /v1/sessions/:id/agent-logs` | Backward compatible. Raw CDP-derived events (coordinates, key codes, URLs). Lower level. |
-| `WS /v1/sessions/:id/agent-traces/stream` | Live stream of new activities while a session is running. |
+| `WS /v1/sessions/:id/agent-traces` | Live stream of new activities while a session is running. |
 
 ### GET /v1/sessions/:id/agent-traces
 
-Returns the full semantic timeline for a finished or in-progress session. For sessions recorded before semantic capture existed the endpoint returns an empty `events` array. Fall back to `/agent-logs` only if you need to support legacy sessions.
+Returns the full semantic timeline for a finished or in-progress session. For sessions recorded before semantic capture existed, the endpoint falls back to CDP-derived activities when available. Those fallback rows are useful for timing and coarse replay, but may not include target metadata like selectors, accessible names, or bounding boxes.
 
 ```bash !! curl -wcn
 curl https://api.steel.dev/v1/sessions/$SESSION_ID/agent-traces \
@@ -46,40 +46,34 @@ Each `AgentActivity` shares a common envelope:
 
 | Field | Type | Notes |
 | ----- | ---- | ----- |
-| `type` | `"click" \| "input" \| "navigate" \| "scroll" \| "drag" \| "keyPress" \| "submit" \| "error"` | The verb shown in the timeline. |
+| `type` | `"click" \| "doubleClick" \| "input" \| "change" \| "navigate" \| "scroll" \| "drag" \| "keyPress" \| "submit" \| "error"` | The activity type. |
 | `timestamp` | ISO 8601 string | Wall clock when the activity happened. |
-| `offsetMs` | number | Milliseconds from session start. Used for video sync. |
-| `url` | string | Page URL at the moment of the activity. |
-| `target` | object | Element metadata (see below). Absent on `navigate`. |
-| `duration` | number | Present on coalesced runs (typing bursts, rapid clicks). Milliseconds. |
-| `raw` | object | The underlying browser event. Shape varies by `type`. |
+| `endTimestamp` | ISO 8601 string | Present on some coalesced runs, such as typing bursts or drags. |
+| `page` | object | Usually `{ url }`, when the page URL is known for the activity. |
+| `target` | object | Element metadata (see below). Absent on `navigate` and some fallback rows. |
 
 The `target` object is the human-readable layer the UI displays:
 
 ```json !! target -wcn
 {
-  "label": "Sign in",
-  "tag": "button",
+  "tagName": "button",
   "role": "button",
   "accessibleName": "Sign in",
+  "text": "Sign in",
   "boundingBox": { "x": 504, "y": 392, "width": 96, "height": 36 },
   "attributes": {
     "data-testid": "sign-in",
     "type": "submit",
     "class": "btn btn-primary"
   },
-  "selectors": {
-    "testId": "[data-testid=sign-in]",
-    "id": null,
-    "aria": "[aria-label='Sign in']",
-    "name": null,
+  "selector": {
     "css": "button[data-testid=sign-in]",
     "xpath": "//button[@data-testid='sign-in']"
   }
 }
 ```
 
-Selectors are listed in priority order: `testId`, `id`, `aria`, `name`, `CSS`, `XPath`. The first non-null value is the canonical selector Steel uses internally.
+Use `target.selector.css` first when it is present. `target.selector.xpath` is included as a fallback, and stable attributes such as `data-testid`, `id`, `name`, `href`, and `aria-*` are available under `target.attributes`.
 
 #### Per-type fields
 
@@ -87,13 +81,13 @@ A handful of activity types carry extra fields beyond the common envelope.
 
 | Type | Extra fields |
 | ---- | ------------ |
-| `click`, `drag` | `x`, `y`, `button`, `clickCount`, `modifiers` |
-| `input` | `length` (number of characters), `redacted` (boolean), `value` (omitted if redacted) |
-| `keyPress` | `key`, `code`, `modifiers` |
-| `navigate` | `fromUrl`, `toUrl`, `reloaded` (boolean) |
-| `scroll` | `deltaX`, `deltaY`, `scrollTop` |
-| `submit` | `formSelectors`, `fields` (array of `{ name, length, redacted }`) |
-| `error` | `message`, `stack`, `source` (`"page" \| "browser"`) |
+| `click`, `doubleClick` | `pointer` with `x`, `y`, `button`, and `clickCount` |
+| `input`, `change` | `value` with `inputType`, `valueLength`, `text`, `redacted`, and `checked` when relevant |
+| `keyPress` | `keyboard` with `key`, `code`, and `text` |
+| `navigate` | `navigation` with `url` |
+| `scroll` | `pointer` with `x` and `y`, plus `delta` with `x` and `y` when available |
+| `drag` | `pointer` with `startX`, `startY`, `endX`, `endY`, and `button`, plus optional `endTarget` |
+| `error` | `error` with `kind` (`"page" \| "browser" \| "request" \| "other"`), `message`, `stack`, and `url` |
 
 ### Live stream over WebSocket
 
@@ -101,8 +95,7 @@ Subscribe to new activities as they happen.
 
 ```javascript !! fetch -wcn
 const ws = new WebSocket(
-  `wss://api.steel.dev/v1/sessions/${sessionId}/agent-traces/stream`,
-  ["steel-api-key", process.env.STEEL_API_KEY],
+  `wss://api.steel.dev/v1/sessions/${sessionId}/agent-traces?token=${authToken}`,
 );
 
 ws.addEventListener("message", (event) => {
@@ -111,7 +104,7 @@ ws.addEventListener("message", (event) => {
 });
 ```
 
-Each message is one `AgentActivity` in the same shape as the REST response. New activities arrive incrementally and may supersede earlier ones. For example, a second click within 500ms of the first arrives as a `double-click` that replaces both rows in the dashboard. If you're rendering your own UI, deduplicate on `(timestamp, type, target.selectors.css)` and re-collapse on receipt.
+Each message contains new log rows from the live session stream. The dashboard converts browser-interaction rows into `AgentActivity` objects and collapses them client-side. For example, a second click within 500ms of the first may become a `doubleClick` activity. If you're rendering your own UI, normalize incoming rows and merge them with the existing timeline before rendering.
 
 When the session ends the socket closes. The same activities are then available statically from the REST endpoint.
 

--- a/content/docs/overview/agent-traces/api.mdx
+++ b/content/docs/overview/agent-traces/api.mdx
@@ -46,7 +46,7 @@ Each `AgentActivity` shares a common envelope:
 
 | Field | Type | Notes |
 | ----- | ---- | ----- |
-| `type` | `"click" \| "doubleClick" \| "input" \| "change" \| "navigate" \| "scroll" \| "drag" \| "keyPress" \| "submit" \| "error"` | The activity type. |
+| `type` | string | One of `click`, `doubleClick`, `input`, `change`, `navigate`, `scroll`, `drag`, `keyPress`, `submit`, or `error`. |
 | `timestamp` | ISO 8601 string | Wall clock when the activity happened. |
 | `endTimestamp` | ISO 8601 string | Present on some coalesced runs, such as typing bursts or drags. |
 | `page` | object | Usually `{ url }`, when the page URL is known for the activity. |

--- a/content/docs/overview/agent-traces/meta.json
+++ b/content/docs/overview/agent-traces/meta.json
@@ -1,0 +1,5 @@
+{
+  "title": "Agent Traces",
+  "root": false,
+  "pages": ["---Agent Traces---", "overview", "timeline", "api"]
+}

--- a/content/docs/overview/agent-traces/overview.mdx
+++ b/content/docs/overview/agent-traces/overview.mdx
@@ -8,9 +8,6 @@ publishedAt: "2026-05-22"
 
 Open any recorded session in the dashboard and you'll find an **Agent Traces** tab next to Console Logs and Network. It turns the whole run into a timeline of semantic activities (clicks, typing, scrolling, navigations, drags, errors), each tied to the exact frame in the session recording.
 
-{/* TODO: screenshot placeholder — full session viewer with Agent Traces tab active */}
-![Agent Traces tab in the session viewer](/images/agent-traces/overview.png)
-
 ### What you get
 
 | Capability | What it does |
@@ -25,7 +22,7 @@ Open any recorded session in the dashboard and you'll find an **Agent Traces** t
 
 **Capture.** Steel injects an in-page script that listens to real DOM events and emits records carrying full element metadata: tag, role, accessible name, every attribute that was on the element, and a bounding box. Sessions recorded before this layer existed fall back to raw CDP input events. The timeline still renders, but without selectors or labels.
 
-**Normalize.** Noisy streams collapse into meaningful units. 10 keypresses become one `input(len=10)`. Two clicks within 500ms become a `double-click`. A redirect chain becomes one `navigate` per distinct URL. Selectors are sorted into priority order (`testId`, `id`, `aria`, `name`, `CSS`, `XPath`), which is what makes the markdown export replayable rather than just readable. Stretches of inactivity longer than 10 seconds become `idle Xs` dividers.
+**Normalize.** Noisy streams collapse into meaningful units. 10 keypresses become one `input(len=10)`. Two clicks within 500ms become one `doubleClick` activity. A redirect chain becomes one `navigate` per distinct URL. Selectors are included as CSS and XPath when available, alongside stable attributes like `data-testid`, `id`, `name`, and `aria-*`, which is what makes the markdown export replayable rather than just readable. Stretches of inactivity longer than 10 seconds become `idle Xs` dividers.
 
 **Present.** The same activities surface in the session viewer (live or replay), through the REST endpoint, over a WebSocket while the session is running, and as the markdown, JSON, and ZIP exports.
 
@@ -50,13 +47,13 @@ curl https://api.steel.dev/v1/sessions/$SESSION_ID/agent-traces \
     {
       "type": "click",
       "timestamp": "2026-05-22T18:03:21.345Z",
-      "offsetMs": 2345,
-      "url": "https://example.com/login",
+      "page": { "url": "https://example.com/login" },
       "target": {
-        "label": "Sign in",
-        "tag": "button",
+        "tagName": "button",
         "role": "button",
-        "selectors": { "testId": "sign-in", "css": "button[data-testid=sign-in]" }
+        "accessibleName": "Sign in",
+        "attributes": { "data-testid": "sign-in" },
+        "selector": { "css": "button[data-testid=sign-in]" }
       }
     }
   ],
@@ -71,7 +68,7 @@ See the [API reference](/overview/agent-traces/api) for the full event shape and
 
 **Debugging an agent run.** Find the error row in the timeline, click it. The video seeks to the failure and the drawer shows the element the agent was interacting with along with the error message. Two clicks instead of ten minutes of scrubbing.
 
-**Reproducing a run as code.** Paste the markdown export into Claude Code, Codex, or Cursor with "write me a Steel script that reproduces this." Selectors are already in priority order, and the export is shaped so an LLM can re-execute it.
+**Reproducing a run as code.** Paste the markdown export into Claude Code, Codex, or Cursor with "write me a Steel script that reproduces this." Stable attributes and selectors are included, and the export is shaped so an LLM can re-execute it.
 
 **Evaluating agent versions.** Replay the same task against different models or prompts, then diff the traces to see which version picked better selectors, took fewer steps, or spent less time idle.
 
@@ -83,7 +80,7 @@ Two REST endpoints plus a WebSocket. Use `/agent-traces` unless you specifically
 
 | Endpoint | Use when |
 | -------- | -------- |
-| `GET /v1/sessions/:id/agent-traces` | **Default.** Semantic activities with selectors, labels, and bounding boxes. Empty array on sessions recorded before semantic capture existed. |
+| `GET /v1/sessions/:id/agent-traces` | **Default.** Semantic activities with selectors, labels, and bounding boxes. Falls back to lower-detail CDP-derived activities for older sessions when semantic capture is unavailable. |
 | `GET /v1/sessions/:id/agent-logs` | Backward compatible. Raw CDP-derived events (coordinates, key codes, URLs). Retained for legacy sessions. |
 
 :::callout

--- a/content/docs/overview/agent-traces/overview.mdx
+++ b/content/docs/overview/agent-traces/overview.mdx
@@ -1,12 +1,12 @@
 ---
 title: Agent Traces
 sidebarTitle: Overview
-description: Every recorded session is a readable timeline of what the agent did — synced frame-by-frame to the video and exportable as a prompt for the next agent.
+description: Every recorded session becomes a readable timeline of what the agent did, synced frame-by-frame with the video and exportable as a prompt for the next agent.
 llm: true
 publishedAt: "2026-05-22"
 ---
 
-Open any recorded session in the dashboard and you'll find an **Agent Traces** tab next to Console Logs and Network. It turns the whole run into a timeline of semantic activities — clicks, typing, scrolling, navigations, drags, errors — each one tied to the exact frame in the session recording.
+Open any recorded session in the dashboard and you'll find an **Agent Traces** tab next to Console Logs and Network. It turns the whole run into a timeline of semantic activities (clicks, typing, scrolling, navigations, drags, errors), each tied to the exact frame in the session recording.
 
 {/* TODO: screenshot placeholder — full session viewer with Agent Traces tab active */}
 ![Agent Traces tab in the session viewer](/images/agent-traces/overview.png)
@@ -16,23 +16,23 @@ Open any recorded session in the dashboard and you'll find an **Agent Traces** t
 | Capability | What it does |
 | ---------- | ------------ |
 | **Timeline** | One row per coalesced activity, with a verb, human-readable target label, page URL, and timestamp. |
-| **Video sync** | Click a row → the video seeks to that frame. Markers on the scrubber show where the action was. |
+| **Video sync** | Click a row, the video seeks to that frame. Markers on the scrubber show where the action was. |
 | **Detail drawer** | Expand any row for element attributes, selector priority, pointer/keyboard details, and raw JSON. |
 | **Live updates** | While a session is running, new activities stream over a WebSocket. |
 | **Exports** | Copy the whole run as markdown (built for pasting into another agent), download JSON, or grab a ZIP with markdown plus screenshots. |
 
 ### How it works
 
-Three layers, same data:
+**Capture.** Steel injects an in-page script that listens to real DOM events and emits records carrying full element metadata: tag, role, accessible name, every attribute that was on the element, and a bounding box. Sessions recorded before this layer existed fall back to raw CDP input events. The timeline still renders, but without selectors or labels.
 
-- **Capture** — Steel injects an in-page script that listens to real DOM events and emits records with full element metadata (tag, role, accessible name, attributes, bounding box). Sessions recorded before this layer existed fall back to raw CDP input events — same timeline shape, but without selectors or labels.
-- **Normalize** — noisy streams collapse into meaningful units. 10 keypresses become one `input(len=10)`, two clicks within 500ms become a `double-click`, a redirect chain becomes one `navigate` per distinct URL. Selectors are sorted into priority order (`testId → id → aria → name → CSS → XPath`) — this is what makes the markdown export replayable, not just readable. Stretches of inactivity longer than 10 seconds become `idle Xs` dividers.
-- **Present** — the same activities surface in the session viewer (live or replay), through the REST endpoint, over a WebSocket while the session is running, and as the markdown / JSON / ZIP exports.
+**Normalize.** Noisy streams collapse into meaningful units. 10 keypresses become one `input(len=10)`. Two clicks within 500ms become a `double-click`. A redirect chain becomes one `navigate` per distinct URL. Selectors are sorted into priority order (`testId`, `id`, `aria`, `name`, `CSS`, `XPath`), which is what makes the markdown export replayable rather than just readable. Stretches of inactivity longer than 10 seconds become `idle Xs` dividers.
+
+**Present.** The same activities surface in the session viewer (live or replay), through the REST endpoint, over a WebSocket while the session is running, and as the markdown, JSON, and ZIP exports.
 
 :::callout
 type: info
-### Captured by the browser, not the agent
-Activities are emitted by an in-page script reading real browser DOM events — they record what the browser observed, not what the agent reported. So `target.label` reflects the page as it actually rendered, which makes the trace usable as an independent record of what an agent saw at any moment.
+### Where the data comes from
+Activities are emitted by an in-page script reading real DOM events. They record what the browser observed, not what the agent reported. So `target.label` reflects what the page actually rendered, which makes the trace usable as an independent record of what an agent saw at any moment.
 :::
 
 ### Quick look at the API
@@ -67,21 +67,24 @@ curl https://api.steel.dev/v1/sessions/$SESSION_ID/agent-traces \
 
 See the [API reference](/overview/agent-traces/api) for the full event shape and the live WebSocket channel.
 
-### What this unlocks
+### Use cases
 
-- **Debug without scrubbing video** — find the error row in the timeline, click it. The video seeks to the failure, the drawer shows the element the agent was interacting with and the error message. Two clicks instead of ten minutes of scrubbing.
-- **Reproduce a run as code** — paste the markdown export into Claude Code, Codex, or Cursor with "write me a Steel script that reproduces this." Selector priority is already done — the export is shaped so an LLM can re-execute it.
-- **Evaluate agent versions** — replay the same task against different models or prompts, then diff the traces. Did the new version pick a better selector, take fewer steps, or spend less time idle?
-- **Audit what an agent actually did** — a timestamped, video-synced record of every interaction in one scrollable view. Useful for customer support investigations, trust and safety reviews, and post-mortems.
+**Debugging an agent run.** Find the error row in the timeline, click it. The video seeks to the failure and the drawer shows the element the agent was interacting with along with the error message. Two clicks instead of ten minutes of scrubbing.
 
-### Two endpoints, one rule
+**Reproducing a run as code.** Paste the markdown export into Claude Code, Codex, or Cursor with "write me a Steel script that reproduces this." Selectors are already in priority order, and the export is shaped so an LLM can re-execute it.
 
-Agent Traces is the **semantic** timeline. Steel injects an in-page script that listens to real DOM events and emits records with full target metadata — that's how a click becomes `click on Sign in` instead of `mouseDown at (412, 287)`.
+**Evaluating agent versions.** Replay the same task against different models or prompts, then diff the traces to see which version picked better selectors, took fewer steps, or spent less time idle.
+
+**Auditing what an agent actually did.** A timestamped, video-synced record of every interaction in one scrollable view. Useful for customer support investigations, safety reviews, and post-mortems.
+
+### Endpoints
+
+Two REST endpoints plus a WebSocket. Use `/agent-traces` unless you specifically need raw CDP data.
 
 | Endpoint | Use when |
 | -------- | -------- |
 | `GET /v1/sessions/:id/agent-traces` | **Default.** Semantic activities with selectors, labels, and bounding boxes. Empty array on sessions recorded before semantic capture existed. |
-| `GET /v1/sessions/:id/agent-logs` | Backward-compatible. Raw CDP-derived events (coordinates, key codes, URLs). Retained for legacy sessions. |
+| `GET /v1/sessions/:id/agent-logs` | Backward compatible. Raw CDP-derived events (coordinates, key codes, URLs). Retained for legacy sessions. |
 
 :::callout
 type: info

--- a/content/docs/overview/agent-traces/overview.mdx
+++ b/content/docs/overview/agent-traces/overview.mdx
@@ -1,0 +1,81 @@
+---
+title: Agent Traces
+sidebarTitle: Overview
+description: Every recorded session is a readable timeline of what the agent did — synced frame-by-frame to the video and exportable as a prompt for the next agent.
+llm: true
+publishedAt: "2026-05-22"
+---
+
+Open any recorded session in the dashboard and you'll find an **Agent Traces** tab next to Console Logs and Network. It turns the whole run into a timeline of semantic activities — clicks, typing, scrolling, navigations, drags, errors — each one tied to the exact frame in the session recording.
+
+{/* TODO: screenshot placeholder — full session viewer with Agent Traces tab active */}
+![Agent Traces tab in the session viewer](/images/agent-traces/overview.png)
+
+### What you get
+
+| Capability | What it does |
+| ---------- | ------------ |
+| **Timeline** | One row per coalesced activity, with a verb, human-readable target label, page URL, and timestamp. |
+| **Video sync** | Click a row → the video seeks to that frame. Markers on the scrubber show where the action was. |
+| **Detail drawer** | Expand any row for element attributes, selector priority, pointer/keyboard details, and raw JSON. |
+| **Live updates** | While a session is running, new activities stream over a WebSocket. |
+| **Exports** | Copy the whole run as markdown (built for pasting into another agent), download JSON, or grab a ZIP with markdown plus screenshots. |
+
+### Quick look at the API
+
+For finished sessions, fetch the semantic timeline as JSON:
+
+```bash !! curl -wcn
+curl https://api.steel.dev/v1/sessions/$SESSION_ID/agent-traces \
+  -H "steel-api-key: $STEEL_API_KEY"
+```
+
+```json !! Response -wcn
+{
+  "events": [
+    {
+      "type": "click",
+      "timestamp": "2026-05-22T18:03:21.345Z",
+      "offsetMs": 2345,
+      "url": "https://example.com/login",
+      "target": {
+        "label": "Sign in",
+        "tag": "button",
+        "role": "button",
+        "selectors": { "testId": "sign-in", "css": "button[data-testid=sign-in]" }
+      }
+    }
+  ],
+  "total": 1,
+  "hasMore": false
+}
+```
+
+See the [API reference](/overview/agent-traces/api) for the full event shape and the live WebSocket channel.
+
+### Three things this unlocks
+
+- **Debugging agent runs**: scroll the timeline, spot the error row, click it. The video jumps to the failure and the drawer shows the element and message. No more scrubbing video looking for the moment something broke.
+- **Reproducing a flow as code**: copy the run as markdown, paste it into Claude Code, Codex, or Cursor with "write me a Steel script that reproduces this." The selectors, step structure, and timing are already there.
+- **Auditing**: a human-readable record of every interaction, with timestamps, in one scrollable view. Useful for trust and safety reviews, customer support investigations, and post-mortems.
+
+### Two endpoints, one rule
+
+Agent Traces is the **semantic** timeline. Steel injects an in-page script that listens to real DOM events and emits records with full target metadata — that's how a click becomes `click on Sign in` instead of `mouseDown at (412, 287)`.
+
+| Endpoint | Use when |
+| -------- | -------- |
+| `GET /v1/sessions/:id/agent-traces` | **Default.** Semantic activities with selectors, labels, and bounding boxes. Empty array on sessions recorded before semantic capture existed. |
+| `GET /v1/sessions/:id/agent-logs` | Backward-compatible. Raw CDP-derived events (coordinates, key codes, URLs). Retained for legacy sessions. |
+
+:::callout
+type: info
+### Where to go next
+Read [Timeline and exports](/overview/agent-traces/timeline) for the dashboard UI and the markdown/JSON/ZIP export formats, or jump to the [API reference](/overview/agent-traces/api) for the event schema and live stream.
+:::
+
+:::callout
+type: help
+### Need help with Agent Traces?
+Reach out on the <span className="font-bold">#help</span> channel on [Discord](https://discord.gg/steel-dev) under the ⭐ community section.
+:::

--- a/content/docs/overview/agent-traces/overview.mdx
+++ b/content/docs/overview/agent-traces/overview.mdx
@@ -21,6 +21,20 @@ Open any recorded session in the dashboard and you'll find an **Agent Traces** t
 | **Live updates** | While a session is running, new activities stream over a WebSocket. |
 | **Exports** | Copy the whole run as markdown (built for pasting into another agent), download JSON, or grab a ZIP with markdown plus screenshots. |
 
+### How it works
+
+Three layers, same data:
+
+- **Capture** — Steel injects an in-page script that listens to real DOM events and emits records with full element metadata (tag, role, accessible name, attributes, bounding box). Sessions recorded before this layer existed fall back to raw CDP input events — same timeline shape, but without selectors or labels.
+- **Normalize** — noisy streams collapse into meaningful units. 10 keypresses become one `input(len=10)`, two clicks within 500ms become a `double-click`, a redirect chain becomes one `navigate` per distinct URL. Selectors are sorted into priority order (`testId → id → aria → name → CSS → XPath`) — this is what makes the markdown export replayable, not just readable. Stretches of inactivity longer than 10 seconds become `idle Xs` dividers.
+- **Present** — the same activities surface in the session viewer (live or replay), through the REST endpoint, over a WebSocket while the session is running, and as the markdown / JSON / ZIP exports.
+
+:::callout
+type: info
+### Captured by the browser, not the agent
+Activities are emitted by an in-page script reading real browser DOM events — they record what the browser observed, not what the agent reported. So `target.label` reflects the page as it actually rendered, which makes the trace usable as an independent record of what an agent saw at any moment.
+:::
+
 ### Quick look at the API
 
 For finished sessions, fetch the semantic timeline as JSON:
@@ -53,11 +67,12 @@ curl https://api.steel.dev/v1/sessions/$SESSION_ID/agent-traces \
 
 See the [API reference](/overview/agent-traces/api) for the full event shape and the live WebSocket channel.
 
-### Three things this unlocks
+### What this unlocks
 
-- **Debugging agent runs**: scroll the timeline, spot the error row, click it. The video jumps to the failure and the drawer shows the element and message. No more scrubbing video looking for the moment something broke.
-- **Reproducing a flow as code**: copy the run as markdown, paste it into Claude Code, Codex, or Cursor with "write me a Steel script that reproduces this." The selectors, step structure, and timing are already there.
-- **Auditing**: a human-readable record of every interaction, with timestamps, in one scrollable view. Useful for trust and safety reviews, customer support investigations, and post-mortems.
+- **Debug without scrubbing video** — find the error row in the timeline, click it. The video seeks to the failure, the drawer shows the element the agent was interacting with and the error message. Two clicks instead of ten minutes of scrubbing.
+- **Reproduce a run as code** — paste the markdown export into Claude Code, Codex, or Cursor with "write me a Steel script that reproduces this." Selector priority is already done — the export is shaped so an LLM can re-execute it.
+- **Evaluate agent versions** — replay the same task against different models or prompts, then diff the traces. Did the new version pick a better selector, take fewer steps, or spend less time idle?
+- **Audit what an agent actually did** — a timestamped, video-synced record of every interaction in one scrollable view. Useful for customer support investigations, trust and safety reviews, and post-mortems.
 
 ### Two endpoints, one rule
 

--- a/content/docs/overview/agent-traces/overview.mdx
+++ b/content/docs/overview/agent-traces/overview.mdx
@@ -1,40 +1,39 @@
 ---
 title: Agent Traces
 sidebarTitle: Overview
-description: Every recorded session becomes a readable timeline of what the agent did, synced frame-by-frame with the video and exportable as a prompt for the next agent.
+description: Review recorded browser sessions as a readable timeline of agent activity, synced with video and exportable for debugging, replay, and handoff.
 llm: true
 publishedAt: "2026-05-22"
 ---
 
-Open any recorded session in the dashboard and you'll find an **Agent Traces** tab next to Console Logs and Network. It turns the whole run into a timeline of semantic activities (clicks, typing, scrolling, navigations, drags, errors), each tied to the exact frame in the session recording.
+Open any recorded session in the dashboard and you'll find an **Agent Traces** tab next to Console Logs and Network. It turns the run into a timeline of agent activity, so you can see what happened without scrubbing through the whole recording.
 
 ### What you get
 
 | Capability | What it does |
 | ---------- | ------------ |
-| **Timeline** | One row per coalesced activity, with a verb, human-readable target label, page URL, and timestamp. |
-| **Video sync** | Click a row, the video seeks to that frame. Markers on the scrubber show where the action was. |
-| **Detail drawer** | Expand any row for element attributes, selector priority, pointer/keyboard details, and raw JSON. |
-| **Live updates** | While a session is running, new activities stream over a WebSocket. |
-| **Exports** | Copy the whole run as markdown (built for pasting into another agent), download JSON, or grab a ZIP with markdown plus screenshots. |
+| **Timeline** | One row per meaningful activity, with a verb, target label, page URL, and timestamp. |
+| **Video sync** | Click a row to jump the recording to the moment that activity happened. |
+| **Details** | Expand a row to inspect the relevant page, element, pointer, keyboard, or error details when available. |
+| **Exports** | Copy the run as markdown, download JSON, or grab a ZIP with markdown plus screenshots. |
 
-### How it works
+### How to use it
 
-**Capture.** Steel injects an in-page script that listens to real DOM events and emits records carrying full element metadata: tag, role, accessible name, every attribute that was on the element, and a bounding box. Sessions recorded before this layer existed fall back to raw CDP input events. The timeline still renders, but without selectors or labels.
+**Review the run.** Start with the timeline to understand the path the agent took: where it navigated, what it clicked, what it typed, where it paused, and where errors happened.
 
-**Normalize.** Noisy streams collapse into meaningful units. 10 keypresses become one `input(len=10)`. Two clicks within 500ms become one `doubleClick` activity. A redirect chain becomes one `navigate` per distinct URL. Selectors are included as CSS and XPath when available, alongside stable attributes like `data-testid`, `id`, `name`, and `aria-*`, which is what makes the markdown export replayable rather than just readable. Stretches of inactivity longer than 10 seconds become `idle Xs` dividers.
+**Jump to the evidence.** Select any row to move the video to that point in the session. This makes it much faster to debug failures, unexpected navigation, or moments where the agent picked the wrong element.
 
-**Present.** The same activities surface in the session viewer (live or replay), through the REST endpoint, over a WebSocket while the session is running, and as the markdown, JSON, and ZIP exports.
+**Hand off context.** Export the trace as markdown when you want another agent or teammate to understand and reproduce the run. Use JSON when you want to analyze the activity data programmatically.
 
 :::callout
 type: info
-### Where the data comes from
-Activities are emitted by an in-page script reading real DOM events. They record what the browser observed, not what the agent reported. So `target.label` reflects what the page actually rendered, which makes the trace usable as an independent record of what an agent saw at any moment.
+### Built from the browser session
+Agent Traces are based on what happened in the browser session, not on what the agent claimed it did. When page context is available, traces include readable target labels and element details to make the run easier to inspect or reproduce.
 :::
 
 ### Quick look at the API
 
-For finished sessions, fetch the semantic timeline as JSON:
+Fetch the trace timeline for a session as JSON:
 
 ```bash !! curl -wcn
 curl https://api.steel.dev/v1/sessions/$SESSION_ID/agent-traces \
@@ -49,10 +48,8 @@ curl https://api.steel.dev/v1/sessions/$SESSION_ID/agent-traces \
       "timestamp": "2026-05-22T18:03:21.345Z",
       "page": { "url": "https://example.com/login" },
       "target": {
-        "tagName": "button",
         "role": "button",
         "accessibleName": "Sign in",
-        "attributes": { "data-testid": "sign-in" },
         "selector": { "css": "button[data-testid=sign-in]" }
       }
     }
@@ -62,31 +59,22 @@ curl https://api.steel.dev/v1/sessions/$SESSION_ID/agent-traces \
 }
 ```
 
-See the [API reference](/overview/agent-traces/api) for the full event shape and the live WebSocket channel.
+See the [API reference](/overview/agent-traces/api) for the response shape and examples.
 
 ### Use cases
 
-**Debugging an agent run.** Find the error row in the timeline, click it. The video seeks to the failure and the drawer shows the element the agent was interacting with along with the error message. Two clicks instead of ten minutes of scrubbing.
+**Debugging an agent run.** Find the error or unexpected action in the timeline, click it, and the video jumps to the right moment. Two clicks instead of ten minutes of scrubbing.
 
-**Reproducing a run as code.** Paste the markdown export into Claude Code, Codex, or Cursor with "write me a Steel script that reproduces this." Stable attributes and selectors are included, and the export is shaped so an LLM can re-execute it.
+**Reproducing a run as code.** Paste the markdown export into Claude Code, Codex, or Cursor with "write me a Steel script that reproduces this." The export is structured so an agent can follow the same path.
 
-**Evaluating agent versions.** Replay the same task against different models or prompts, then diff the traces to see which version picked better selectors, took fewer steps, or spent less time idle.
+**Evaluating agent versions.** Replay the same task against different models or prompts, then compare traces to see which version took fewer steps or handled the page more reliably.
 
 **Auditing what an agent actually did.** A timestamped, video-synced record of every interaction in one scrollable view. Useful for customer support investigations, safety reviews, and post-mortems.
-
-### Endpoints
-
-Two REST endpoints plus a WebSocket. Use `/agent-traces` unless you specifically need raw CDP data.
-
-| Endpoint | Use when |
-| -------- | -------- |
-| `GET /v1/sessions/:id/agent-traces` | **Default.** Semantic activities with selectors, labels, and bounding boxes. Falls back to lower-detail CDP-derived activities for older sessions when semantic capture is unavailable. |
-| `GET /v1/sessions/:id/agent-logs` | Backward compatible. Raw CDP-derived events (coordinates, key codes, URLs). Retained for legacy sessions. |
 
 :::callout
 type: info
 ### Where to go next
-Read [Timeline and exports](/overview/agent-traces/timeline) for the dashboard UI and the markdown/JSON/ZIP export formats, or jump to the [API reference](/overview/agent-traces/api) for the event schema and live stream.
+Read [Timeline and exports](/overview/agent-traces/timeline) for the dashboard UI and export formats, or jump to the [API reference](/overview/agent-traces/api) for the REST endpoint.
 :::
 
 :::callout
@@ -94,3 +82,4 @@ type: help
 ### Need help with Agent Traces?
 Reach out on the <span className="font-bold">#help</span> channel on [Discord](https://discord.gg/steel-dev) under the ⭐ community section.
 :::
+

--- a/content/docs/overview/agent-traces/timeline.mdx
+++ b/content/docs/overview/agent-traces/timeline.mdx
@@ -6,7 +6,7 @@ llm: true
 publishedAt: "2026-05-22"
 ---
 
-The Agent Traces tab lives in the session viewer console, next to Console Logs and Network. It's available on every session — open one from the dashboard and switch tabs.
+The Agent Traces tab lives in the session viewer console, next to Console Logs and Network. Open a session from the dashboard and switch tabs.
 
 {/* TODO: screenshot placeholder — close-up of the timeline column with rows */}
 ![Timeline column in the session viewer](/images/agent-traces/timeline.png)
@@ -18,8 +18,8 @@ Each row is one coalesced activity. From left to right:
 | Element | What it shows |
 | ------- | ------------- |
 | **Icon + verb** | `click`, `double-click`, `typed`, `key press`, `navigate`, `scroll`, `drag`, `submit`, or `error`. Color-coded for scanning. |
-| **Target label** | The most human-readable name we can derive — accessible name → ARIA label → placeholder → visible text → test-id → tag summary. So you see `Sign in`, not `<button class="x-3f9a">`. |
-| **Page context** | The URL the activity happened on. Consecutive rows on the same page are grouped so a stretch reads as a chapter. |
+| **Target label** | The most readable name available for the element: accessible name, then ARIA label, placeholder, visible text, test-id, or tag summary. So you see `Sign in`, not `<button class="x-3f9a">`. |
+| **Page context** | The URL the activity happened on. Consecutive rows on the same page are grouped, so a stretch of activity reads as one section. |
 | **Timestamp** | Wall clock plus an offset from session start (e.g. `0:02.345`) for cross-referencing with the video. |
 
 Rows read like sentences: `click on Sign in`, `input(len=17) on Email field`, `navigate to /home`.
@@ -36,31 +36,30 @@ The timeline collapses noisy interaction bursts into the unit you'd actually des
 | Reloading the same URL twice | One `navigate` row |
 | More than 10 seconds with no activity | An `idle 23s` divider between the surrounding rows |
 
-The idle dividers are especially useful for telling thinking apart from acting in long agent runs.
+The idle dividers help separate thinking from acting in long agent runs.
 
 ### Video sync
 
-The timeline and the video are two views of the same thing.
+The timeline and the video are linked. Clicking a row seeks the video to that exact frame. The seek uses HLS program-date-time, so it's frame-accurate, not estimated from row index.
 
-- **Click a row** → the video seeks to that exact frame. The seek uses HLS program-date-time, so it's frame-accurate, not estimated from row index.
-- **Markers on the scrubber** — every activity gets a small color-coded tick on the video progress bar, matching the timeline icon colors. You can see at a glance where the dense bursts of work were and where the agent was idle.
-- **Hover the scrubber** — the bar expands and shows a thumbnail preview at that timestamp. Drag along it to scrub.
-- **Active highlight** — as the video plays, the marker nearest the current frame lights up and the matching row highlights in the timeline. Hover a marker on the bar and the row scrolls into view.
+Every activity also gets a small color-coded tick on the video progress bar, matching the timeline icon colors. You can see at a glance where the dense bursts of work were and where the agent was idle. Hovering the scrubber expands it and shows a thumbnail preview at that timestamp. Drag along the bar to scrub.
+
+As the video plays, the marker nearest the current frame lights up and the matching row highlights in the timeline. Hover a marker on the bar and the row scrolls into view.
 
 {/* TODO: screenshot placeholder — scrubber with color-coded markers and hover thumbnail */}
 ![Scrubber markers synced with the timeline](/images/agent-traces/scrubber.png)
 
 ### The detail drawer
 
-Click anywhere on a row (not just the icon) and it expands inline.
+Click anywhere on a row (not just the icon) and it expands inline. The drawer contains:
 
-- **Element details** — tag, role, accessible name, every attribute that was on the element (`id`, `class`, `name`, `aria-*`, `href`, `data-testid`, `type`, `placeholder`…) and a bounding box.
-- **Selectors** — a prioritized list of how to find this element again: `testId → id → aria → name → CSS → XPath`. This is the same priority Steel uses internally to pick the canonical selector for an element.
-- **Pointer or keyboard details** — exact `x`/`y`, button, click count, key code, modifiers, when relevant.
-- **Page URL** at the moment the activity happened.
-- **Raw JSON** of the underlying event, with a copy button.
-- **Thumbnail** of the video frame at that instant. Click it for a full-size preview.
-- **Duration** — for coalesced runs (the typing burst, the rapid click sequence) the drawer shows how long the run took.
+- Element details: tag, role, accessible name, every attribute that was on the element (`id`, `class`, `name`, `aria-*`, `href`, `data-testid`, `type`, `placeholder`...), and a bounding box.
+- A prioritized list of selectors for finding the element again: `testId`, `id`, `aria`, `name`, `CSS`, `XPath`. This is the same priority Steel uses internally to pick the canonical selector for an element.
+- Pointer or keyboard details when relevant: exact `x` and `y`, button, click count, key code, modifiers.
+- The page URL at the moment the activity happened.
+- Raw JSON of the underlying event, with a copy button.
+- A thumbnail of the video frame at that instant. Click it for a full-size preview.
+- For coalesced runs (a typing burst, a rapid click sequence), the duration of the run.
 
 For `navigate` rows there's also an **Open** button that opens the URL in a new tab.
 
@@ -69,7 +68,7 @@ For `navigate` rows there's also an **Open** button that opens the URL in a new 
 
 ### Live updates
 
-For sessions that are currently running, the timeline streams in real time over a WebSocket. New activities arrive incrementally, get deduplicated against what's already on screen, sorted into place, and re-collapsed. Watching a live run feels like watching the agent think out loud, action by action.
+For sessions that are currently running, the timeline streams in real time over a WebSocket. New activities arrive incrementally, get deduplicated against what's already on screen, sorted into place, and re-collapsed.
 
 When the session ends, the same data is available statically via [the REST endpoint](/overview/agent-traces/api).
 
@@ -85,7 +84,7 @@ Three export formats, all reachable from the Agent Traces tab on a finished sess
 
 #### Copy as markdown
 
-This is the export designed for AI agents. The output reads like a recipe an automation agent could re-execute — and that's the explicit intent.
+This is the export built for AI agents. The output reads like a recipe an automation agent could re-execute.
 
 The format includes:
 
@@ -105,7 +104,7 @@ A trimmed example:
 
 This document is an exported timeline of a recorded browser session.
 Each step is one activity the agent took. Selectors are listed in
-priority order (testId → id → aria → name → CSS → XPath).
+priority order (testId, id, aria, name, CSS, XPath).
 
 ## https://example.com/login
 
@@ -131,15 +130,15 @@ priority order (testId → id → aria → name → CSS → XPath).
 6. **navigate** to `https://example.com/home` *(0:18.120)*
 ```
 
-Paste it into Claude Code, Codex, OpenCode, or Cursor with `write me a Steel script that reproduces this run` — the selectors, step structure, and timing are designed for exactly that.
+Paste it into Claude Code, Codex, OpenCode, or Cursor with `write me a Steel script that reproduces this run`. The selectors, step structure, and timing are already in the right shape for that.
 
 #### Download JSON
 
-The JSON export matches the [API response shape](/overview/agent-traces/api) — `{ events, total, hasMore }` with one `AgentActivity` per row. Use it when you want to filter, diff, or feed the run into your own tooling rather than another LLM.
+The JSON export matches the [API response shape](/overview/agent-traces/api): `{ events, total, hasMore }` with one `AgentActivity` per row. Use it when you want to filter, diff, or feed the run into your own tooling rather than another LLM.
 
 #### Download ZIP
 
-The ZIP bundles the markdown document with screenshots of each page state taken at the moment the agent first landed there. The screenshots are referenced inline from the markdown, so unzipping and opening the `.md` gives you a faithful, portable transcript. Good for sharing a run outside the dashboard — bug reports, customer support tickets, post-mortems.
+The ZIP bundles the markdown document with screenshots of each page state, taken at the moment the agent first landed there. The screenshots are referenced inline from the markdown, so unzipping and opening the `.md` gives you a portable transcript. Good for sharing a run outside the dashboard: bug reports, customer support tickets, post-mortems.
 
 :::callout
 type: tip

--- a/content/docs/overview/agent-traces/timeline.mdx
+++ b/content/docs/overview/agent-traces/timeline.mdx
@@ -1,0 +1,154 @@
+---
+title: Timeline and exports
+sidebarTitle: Timeline & exports
+description: How to read the Agent Traces timeline in the session viewer, sync it with the video, expand the detail drawer, and export the run as markdown, JSON, or a ZIP bundle.
+llm: true
+publishedAt: "2026-05-22"
+---
+
+The Agent Traces tab lives in the session viewer console, next to Console Logs and Network. It's available on every session — open one from the dashboard and switch tabs.
+
+{/* TODO: screenshot placeholder — close-up of the timeline column with rows */}
+![Timeline column in the session viewer](/images/agent-traces/timeline.png)
+
+### Anatomy of a row
+
+Each row is one coalesced activity. From left to right:
+
+| Element | What it shows |
+| ------- | ------------- |
+| **Icon + verb** | `click`, `double-click`, `typed`, `key press`, `navigate`, `scroll`, `drag`, `submit`, or `error`. Color-coded for scanning. |
+| **Target label** | The most human-readable name we can derive — accessible name → ARIA label → placeholder → visible text → test-id → tag summary. So you see `Sign in`, not `<button class="x-3f9a">`. |
+| **Page context** | The URL the activity happened on. Consecutive rows on the same page are grouped so a stretch reads as a chapter. |
+| **Timestamp** | Wall clock plus an offset from session start (e.g. `0:02.345`) for cross-referencing with the video. |
+
+Rows read like sentences: `click on Sign in`, `input(len=17) on Email field`, `navigate to /home`.
+
+### Coalescing rules
+
+The timeline collapses noisy interaction bursts into the unit you'd actually describe.
+
+| Raw activity | Shown as |
+| ------------ | -------- |
+| Typing a 17-character email | One `input(len=17)` row, not 17 keystroke rows |
+| Two clicks on the same target within 500ms | One `double-click` row |
+| Redirect chain `/login → /auth → /home` | Three `navigate` rows (each step is meaningful) |
+| Reloading the same URL twice | One `navigate` row |
+| More than 10 seconds with no activity | An `idle 23s` divider between the surrounding rows |
+
+The idle dividers are especially useful for telling thinking apart from acting in long agent runs.
+
+### Video sync
+
+The timeline and the video are two views of the same thing.
+
+- **Click a row** → the video seeks to that exact frame. The seek uses HLS program-date-time, so it's frame-accurate, not estimated from row index.
+- **Markers on the scrubber** — every activity gets a small color-coded tick on the video progress bar, matching the timeline icon colors. You can see at a glance where the dense bursts of work were and where the agent was idle.
+- **Hover the scrubber** — the bar expands and shows a thumbnail preview at that timestamp. Drag along it to scrub.
+- **Active highlight** — as the video plays, the marker nearest the current frame lights up and the matching row highlights in the timeline. Hover a marker on the bar and the row scrolls into view.
+
+{/* TODO: screenshot placeholder — scrubber with color-coded markers and hover thumbnail */}
+![Scrubber markers synced with the timeline](/images/agent-traces/scrubber.png)
+
+### The detail drawer
+
+Click anywhere on a row (not just the icon) and it expands inline.
+
+- **Element details** — tag, role, accessible name, every attribute that was on the element (`id`, `class`, `name`, `aria-*`, `href`, `data-testid`, `type`, `placeholder`…) and a bounding box.
+- **Selectors** — a prioritized list of how to find this element again: `testId → id → aria → name → CSS → XPath`. This is the same priority Steel uses internally to pick the canonical selector for an element.
+- **Pointer or keyboard details** — exact `x`/`y`, button, click count, key code, modifiers, when relevant.
+- **Page URL** at the moment the activity happened.
+- **Raw JSON** of the underlying event, with a copy button.
+- **Thumbnail** of the video frame at that instant. Click it for a full-size preview.
+- **Duration** — for coalesced runs (the typing burst, the rapid click sequence) the drawer shows how long the run took.
+
+For `navigate` rows there's also an **Open** button that opens the URL in a new tab.
+
+{/* TODO: screenshot placeholder — expanded drawer showing element details + selectors */}
+![Expanded detail drawer for a click activity](/images/agent-traces/drawer.png)
+
+### Live updates
+
+For sessions that are currently running, the timeline streams in real time over a WebSocket. New activities arrive incrementally, get deduplicated against what's already on screen, sorted into place, and re-collapsed. Watching a live run feels like watching the agent think out loud, action by action.
+
+When the session ends, the same data is available statically via [the REST endpoint](/overview/agent-traces/api).
+
+### Exports
+
+Three export formats, all reachable from the Agent Traces tab on a finished session.
+
+| Export | What you get | Use when |
+| ------ | ------------ | -------- |
+| **Copy as markdown** | A single markdown document, built for pasting into another agent. | You want the next agent to read and reproduce the run. |
+| **Download JSON** | The full event array, same shape as the API response. | You want to drive analysis or replay programmatically. |
+| **Download ZIP** | The markdown document plus per-page-state screenshots, bundled in one archive. | You want a portable, self-contained record (e.g. for a bug report or audit). |
+
+#### Copy as markdown
+
+This is the export designed for AI agents. The output reads like a recipe an automation agent could re-execute — and that's the explicit intent.
+
+The format includes:
+
+- A built-in preamble that explains its own format, so the receiving agent knows what it's looking at without extra prompting.
+- `##` headings for each page visit.
+- Numbered steps for each activity, with the time offset.
+- Sub-bullets exposing stable identifiers and selectors for each element.
+- `at (x, y)` pointer coordinates and bounding boxes.
+- `*(idle 23s)*` markers between steps.
+- Sensitive values (password fields, credit cards) replaced with `<redacted>`.
+- Optionally, inline screenshots of each page state.
+
+A trimmed example:
+
+```markdown !! agent-traces.md -wcn
+# Steel session a3f8...c21 — agent trace
+
+This document is an exported timeline of a recorded browser session.
+Each step is one activity the agent took. Selectors are listed in
+priority order (testId → id → aria → name → CSS → XPath).
+
+## https://example.com/login
+
+1. **navigate** to `https://example.com/login` *(0:00.000)*
+2. **click** on **Email** field *(0:02.345)*
+   - selector: `input[data-testid=email]`
+   - at (412, 287)
+3. **input(len=17)** on **Email** field *(0:03.110)*
+   - value: `user@example.com`
+   - selector: `input[data-testid=email]`
+4. **input(len=12)** on **Password** field *(0:04.802)*
+   - value: `<redacted>`
+   - selector: `input[name=password]`
+
+*(idle 12s)*
+
+5. **click** on **Sign in** button *(0:17.430)*
+   - selector: `button[data-testid=sign-in]`
+   - at (520, 410)
+
+## https://example.com/home
+
+6. **navigate** to `https://example.com/home` *(0:18.120)*
+```
+
+Paste it into Claude Code, Codex, OpenCode, or Cursor with `write me a Steel script that reproduces this run` — the selectors, step structure, and timing are designed for exactly that.
+
+#### Download JSON
+
+The JSON export matches the [API response shape](/overview/agent-traces/api) — `{ events, total, hasMore }` with one `AgentActivity` per row. Use it when you want to filter, diff, or feed the run into your own tooling rather than another LLM.
+
+#### Download ZIP
+
+The ZIP bundles the markdown document with screenshots of each page state taken at the moment the agent first landed there. The screenshots are referenced inline from the markdown, so unzipping and opening the `.md` gives you a faithful, portable transcript. Good for sharing a run outside the dashboard — bug reports, customer support tickets, post-mortems.
+
+:::callout
+type: tip
+### Redaction is automatic for known-sensitive fields
+Password fields and credit-card inputs are replaced with `<redacted>` in both the markdown export and the ZIP. Other input values come through verbatim, so review before sharing if you ran the agent against real user data.
+:::
+
+:::callout
+type: help
+### Need help with Agent Traces?
+Reach out on the <span className="font-bold">#help</span> channel on [Discord](https://discord.gg/steel-dev) under the ⭐ community section.
+:::

--- a/content/docs/overview/agent-traces/timeline.mdx
+++ b/content/docs/overview/agent-traces/timeline.mdx
@@ -8,16 +8,13 @@ publishedAt: "2026-05-22"
 
 The Agent Traces tab lives in the session viewer console, next to Console Logs and Network. Open a session from the dashboard and switch tabs.
 
-{/* TODO: screenshot placeholder — close-up of the timeline column with rows */}
-![Timeline column in the session viewer](/images/agent-traces/timeline.png)
-
 ### Anatomy of a row
 
 Each row is one coalesced activity. From left to right:
 
 | Element | What it shows |
 | ------- | ------------- |
-| **Icon + verb** | `click`, `double-click`, `typed`, `key press`, `navigate`, `scroll`, `drag`, `submit`, or `error`. Color-coded for scanning. |
+| **Icon + verb** | `click`, `doubleClick`, `input`, `change`, `keyPress`, `navigate`, `scroll`, `drag`, `submit`, or `error`. Color-coded for scanning. |
 | **Target label** | The most readable name available for the element: accessible name, then ARIA label, placeholder, visible text, test-id, or tag summary. So you see `Sign in`, not `<button class="x-3f9a">`. |
 | **Page context** | The URL the activity happened on. Consecutive rows on the same page are grouped, so a stretch of activity reads as one section. |
 | **Timestamp** | Wall clock plus an offset from session start (e.g. `0:02.345`) for cross-referencing with the video. |
@@ -31,7 +28,7 @@ The timeline collapses noisy interaction bursts into the unit you'd actually des
 | Raw activity | Shown as |
 | ------------ | -------- |
 | Typing a 17-character email | One `input(len=17)` row, not 17 keystroke rows |
-| Two clicks on the same target within 500ms | One `double-click` row |
+| Two clicks on the same target within 500ms | One `doubleClick` row |
 | Redirect chain `/login → /auth → /home` | Three `navigate` rows (each step is meaningful) |
 | Reloading the same URL twice | One `navigate` row |
 | More than 10 seconds with no activity | An `idle 23s` divider between the surrounding rows |
@@ -46,15 +43,12 @@ Every activity also gets a small color-coded tick on the video progress bar, mat
 
 As the video plays, the marker nearest the current frame lights up and the matching row highlights in the timeline. Hover a marker on the bar and the row scrolls into view.
 
-{/* TODO: screenshot placeholder — scrubber with color-coded markers and hover thumbnail */}
-![Scrubber markers synced with the timeline](/images/agent-traces/scrubber.png)
-
 ### The detail drawer
 
 Click anywhere on a row (not just the icon) and it expands inline. The drawer contains:
 
 - Element details: tag, role, accessible name, every attribute that was on the element (`id`, `class`, `name`, `aria-*`, `href`, `data-testid`, `type`, `placeholder`...), and a bounding box.
-- A prioritized list of selectors for finding the element again: `testId`, `id`, `aria`, `name`, `CSS`, `XPath`. This is the same priority Steel uses internally to pick the canonical selector for an element.
+- Selectors for finding the element again, including CSS and XPath when available.
 - Pointer or keyboard details when relevant: exact `x` and `y`, button, click count, key code, modifiers.
 - The page URL at the moment the activity happened.
 - Raw JSON of the underlying event, with a copy button.
@@ -62,9 +56,6 @@ Click anywhere on a row (not just the icon) and it expands inline. The drawer co
 - For coalesced runs (a typing burst, a rapid click sequence), the duration of the run.
 
 For `navigate` rows there's also an **Open** button that opens the URL in a new tab.
-
-{/* TODO: screenshot placeholder — expanded drawer showing element details + selectors */}
-![Expanded detail drawer for a click activity](/images/agent-traces/drawer.png)
 
 ### Live updates
 
@@ -91,7 +82,7 @@ The format includes:
 - A built-in preamble that explains its own format, so the receiving agent knows what it's looking at without extra prompting.
 - `##` headings for each page visit.
 - Numbered steps for each activity, with the time offset.
-- Sub-bullets exposing stable identifiers and selectors for each element.
+- Sub-bullets exposing stable attributes and CSS/XPath selectors for each element.
 - `at (x, y)` pointer coordinates and bounding boxes.
 - `*(idle 23s)*` markers between steps.
 - Sensitive values (password fields, credit cards) replaced with `<redacted>`.
@@ -100,41 +91,36 @@ The format includes:
 A trimmed example:
 
 ```markdown !! agent-traces.md -wcn
-# Steel session a3f8...c21 — agent trace
+# Browser session
 
-This document is an exported timeline of a recorded browser session.
-Each step is one activity the agent took. Selectors are listed in
-priority order (testId, id, aria, name, CSS, XPath).
+Recording of a real user's interaction with a web app, structured for replay by an automation agent.
 
 ## https://example.com/login
 
-1. **navigate** to `https://example.com/login` *(0:00.000)*
-2. **click** on **Email** field *(0:02.345)*
-   - selector: `input[data-testid=email]`
-   - at (412, 287)
-3. **input(len=17)** on **Email** field *(0:03.110)*
-   - value: `user@example.com`
-   - selector: `input[data-testid=email]`
-4. **input(len=12)** on **Password** field *(0:04.802)*
-   - value: `<redacted>`
-   - selector: `input[name=password]`
+1. `0:02.345` **Click** textbox "Email" at (412, 287)
+   - testId: `email`
+   - CSS: `input[data-testid=email]`
+2. `0:03.110` **Type** "user@example.com" into textbox "Email"
+   - testId: `email`
+   - CSS: `input[data-testid=email]`
+3. `0:04.802` **Type** <redacted, 12 chars> into textbox "Password"
+   - name: `password`
+   - CSS: `input[name=password]`
 
 *(idle 12s)*
 
-5. **click** on **Sign in** button *(0:17.430)*
-   - selector: `button[data-testid=sign-in]`
-   - at (520, 410)
+4. `0:17.430` **Click** button "Sign in" at (520, 410)
+   - testId: `sign-in`
+   - CSS: `button[data-testid=sign-in]`
 
 ## https://example.com/home
-
-6. **navigate** to `https://example.com/home` *(0:18.120)*
 ```
 
 Paste it into Claude Code, Codex, OpenCode, or Cursor with `write me a Steel script that reproduces this run`. The selectors, step structure, and timing are already in the right shape for that.
 
 #### Download JSON
 
-The JSON export matches the [API response shape](/overview/agent-traces/api): `{ events, total, hasMore }` with one `AgentActivity` per row. Use it when you want to filter, diff, or feed the run into your own tooling rather than another LLM.
+The JSON export contains the session metadata plus one `AgentActivity` per row: `{ session, activities }`. The activity objects use the same event shape as the [API response](/overview/agent-traces/api). Use it when you want to filter, diff, or feed the run into your own tooling rather than another LLM.
 
 #### Download ZIP
 

--- a/content/docs/overview/agent-traces/timeline.mdx
+++ b/content/docs/overview/agent-traces/timeline.mdx
@@ -1,7 +1,7 @@
 ---
 title: Timeline and exports
 sidebarTitle: Timeline & exports
-description: How to read the Agent Traces timeline in the session viewer, sync it with the video, expand the detail drawer, and export the run as markdown, JSON, or a ZIP bundle.
+description: How to read the Agent Traces timeline in the session viewer, sync it with the video, and export the run as markdown, JSON, or a ZIP bundle.
 llm: true
 publishedAt: "2026-05-22"
 ---
@@ -10,94 +10,75 @@ The Agent Traces tab lives in the session viewer console, next to Console Logs a
 
 ### Anatomy of a row
 
-Each row is one coalesced activity. From left to right:
+Each row summarizes one meaningful browser activity. From left to right:
 
 | Element | What it shows |
 | ------- | ------------- |
-| **Icon + verb** | `click`, `doubleClick`, `input`, `change`, `keyPress`, `navigate`, `scroll`, `drag`, `submit`, or `error`. Color-coded for scanning. |
-| **Target label** | The most readable name available for the element: accessible name, then ARIA label, placeholder, visible text, test-id, or tag summary. So you see `Sign in`, not `<button class="x-3f9a">`. |
-| **Page context** | The URL the activity happened on. Consecutive rows on the same page are grouped, so a stretch of activity reads as one section. |
-| **Timestamp** | Wall clock plus an offset from session start (e.g. `0:02.345`) for cross-referencing with the video. |
+| **Icon + verb** | The type of activity, such as `click`, `input`, `navigate`, `scroll`, `drag`, or `error`. |
+| **Target label** | A readable name for the element when one is available, such as `Sign in` or `Email field`. |
+| **Page context** | The URL the activity happened on. Consecutive rows on the same page are grouped together. |
+| **Timestamp** | Wall clock plus an offset from session start for cross-referencing with the video. |
 
-Rows read like sentences: `click on Sign in`, `input(len=17) on Email field`, `navigate to /home`.
+Rows read like sentences: `click on Sign in`, `type into Email field`, `navigate to /home`.
 
-### Coalescing rules
+### Activity grouping
 
-The timeline collapses noisy interaction bursts into the unit you'd actually describe.
+Agent Traces group noisy browser interactions into the units you would actually describe when reviewing a run. A burst of typing is shown as a single input activity, repeated navigation is easier to scan, and idle periods help separate thinking from acting in longer sessions.
 
-| Raw activity | Shown as |
-| ------------ | -------- |
-| Typing a 17-character email | One `input(len=17)` row, not 17 keystroke rows |
-| Two clicks on the same target within 500ms | One `doubleClick` row |
-| Redirect chain `/login → /auth → /home` | Three `navigate` rows (each step is meaningful) |
-| Reloading the same URL twice | One `navigate` row |
-| More than 10 seconds with no activity | An `idle 23s` divider between the surrounding rows |
-
-The idle dividers help separate thinking from acting in long agent runs.
+This makes the timeline useful for review without turning it into a raw event log.
 
 ### Video sync
 
-The timeline and the video are linked. Clicking a row seeks the video to that exact frame. The seek uses HLS program-date-time, so it's frame-accurate, not estimated from row index.
+The timeline and the video are linked. Clicking a row seeks the recording to the moment that activity happened.
 
-Every activity also gets a small color-coded tick on the video progress bar, matching the timeline icon colors. You can see at a glance where the dense bursts of work were and where the agent was idle. Hovering the scrubber expands it and shows a thumbnail preview at that timestamp. Drag along the bar to scrub.
+Activity markers appear on the video progress bar, so you can see where the run was dense with actions and where it slowed down. As the video plays, the matching timeline row highlights.
 
-As the video plays, the marker nearest the current frame lights up and the matching row highlights in the timeline. Hover a marker on the bar and the row scrolls into view.
+### Details
 
-### The detail drawer
+Click a row to expand it inline. Depending on the activity, details can include:
 
-Click anywhere on a row (not just the icon) and it expands inline. The drawer contains:
-
-- Element details: tag, role, accessible name, every attribute that was on the element (`id`, `class`, `name`, `aria-*`, `href`, `data-testid`, `type`, `placeholder`...), and a bounding box.
-- Selectors for finding the element again, including CSS and XPath when available.
-- Pointer or keyboard details when relevant: exact `x` and `y`, button, click count, key code, modifiers.
 - The page URL at the moment the activity happened.
-- Raw JSON of the underlying event, with a copy button.
-- A thumbnail of the video frame at that instant. Click it for a full-size preview.
-- For coalesced runs (a typing burst, a rapid click sequence), the duration of the run.
+- Element context such as role, accessible name, visible text, and useful attributes.
+- Selectors when available.
+- Pointer, keyboard, navigation, or error details.
+- A thumbnail from the recording near that moment.
 
-For `navigate` rows there's also an **Open** button that opens the URL in a new tab.
-
-### Live updates
-
-For sessions that are currently running, the timeline streams in real time over a WebSocket. New activities arrive incrementally, get deduplicated against what's already on screen, sorted into place, and re-collapsed.
-
-When the session ends, the same data is available statically via [the REST endpoint](/overview/agent-traces/api).
+For `navigate` rows, the **Open** button opens the URL in a new tab.
 
 ### Exports
 
-Three export formats, all reachable from the Agent Traces tab on a finished session.
+Three export formats are available from the Agent Traces tab on a finished session.
 
 | Export | What you get | Use when |
 | ------ | ------------ | -------- |
 | **Copy as markdown** | A single markdown document, built for pasting into another agent. | You want the next agent to read and reproduce the run. |
-| **Download JSON** | The full event array, same shape as the API response. | You want to drive analysis or replay programmatically. |
-| **Download ZIP** | The markdown document plus per-page-state screenshots, bundled in one archive. | You want a portable, self-contained record (e.g. for a bug report or audit). |
+| **Download JSON** | The activity data for the session. | You want to filter, diff, or analyze the run programmatically. |
+| **Download ZIP** | The markdown document plus screenshots, bundled in one archive. | You want a portable record for a bug report, support ticket, or audit. |
 
 #### Copy as markdown
 
-This is the export built for AI agents. The output reads like a recipe an automation agent could re-execute.
+This is the export built for AI agents. The output reads like a recipe an automation agent can follow.
 
 The format includes:
 
-- A built-in preamble that explains its own format, so the receiving agent knows what it's looking at without extra prompting.
+- A short preamble that explains the structure.
 - `##` headings for each page visit.
 - Numbered steps for each activity, with the time offset.
-- Sub-bullets exposing stable attributes and CSS/XPath selectors for each element.
-- `at (x, y)` pointer coordinates and bounding boxes.
-- `*(idle 23s)*` markers between steps.
-- Sensitive values (password fields, credit cards) replaced with `<redacted>`.
-- Optionally, inline screenshots of each page state.
+- Relevant element labels, identifiers, and selectors when available.
+- Idle markers between longer pauses.
+- Sensitive values, such as password fields and credit-card inputs, replaced with `<redacted>`.
+- Optional screenshots of page states.
 
 A trimmed example:
 
 ```markdown !! agent-traces.md -wcn
 # Browser session
 
-Recording of a real user's interaction with a web app, structured for replay by an automation agent.
+Recording of a real browser session, structured for review and replay by an automation agent.
 
 ## https://example.com/login
 
-1. `0:02.345` **Click** textbox "Email" at (412, 287)
+1. `0:02.345` **Click** textbox "Email"
    - testId: `email`
    - CSS: `input[data-testid=email]`
 2. `0:03.110` **Type** "user@example.com" into textbox "Email"
@@ -109,27 +90,27 @@ Recording of a real user's interaction with a web app, structured for replay by 
 
 *(idle 12s)*
 
-4. `0:17.430` **Click** button "Sign in" at (520, 410)
+4. `0:17.430` **Click** button "Sign in"
    - testId: `sign-in`
    - CSS: `button[data-testid=sign-in]`
 
 ## https://example.com/home
 ```
 
-Paste it into Claude Code, Codex, OpenCode, or Cursor with `write me a Steel script that reproduces this run`. The selectors, step structure, and timing are already in the right shape for that.
+Paste it into Claude Code, Codex, OpenCode, or Cursor with `write me a Steel script that reproduces this run`.
 
 #### Download JSON
 
-The JSON export contains the session metadata plus one `AgentActivity` per row: `{ session, activities }`. The activity objects use the same event shape as the [API response](/overview/agent-traces/api). Use it when you want to filter, diff, or feed the run into your own tooling rather than another LLM.
+The JSON export contains the session metadata and activity data. Use it when you want to filter, diff, or feed the run into your own tooling rather than another LLM.
 
 #### Download ZIP
 
-The ZIP bundles the markdown document with screenshots of each page state, taken at the moment the agent first landed there. The screenshots are referenced inline from the markdown, so unzipping and opening the `.md` gives you a portable transcript. Good for sharing a run outside the dashboard: bug reports, customer support tickets, post-mortems.
+The ZIP bundles the markdown document with screenshots of page states. The screenshots are referenced from the markdown, so unzipping and opening the `.md` gives you a portable transcript.
 
 :::callout
 type: tip
 ### Redaction is automatic for known-sensitive fields
-Password fields and credit-card inputs are replaced with `<redacted>` in both the markdown export and the ZIP. Other input values come through verbatim, so review before sharing if you ran the agent against real user data.
+Password fields and credit-card inputs are replaced with `<redacted>` in both the markdown export and the ZIP. Other input values can appear in exports, so review before sharing if you ran the agent against real user data.
 :::
 
 :::callout

--- a/content/docs/overview/meta.json
+++ b/content/docs/overview/meta.json
@@ -10,6 +10,7 @@
     "pricinglimits",
     "...guides",
     "...sessions-api",
+    "...agent-traces",
     "...credentials-api",
     "...files-api",
     "...extensions-api",


### PR DESCRIPTION
## Summary

Adds a new top-level docs section under `overview/agent-traces` covering the Agent Traces feature that landed in changelog #026.

Three pages:

- **`overview.mdx`** — what Agent Traces is, the capture / normalize / present layering, a quick `curl` example, four developer-oriented use cases (debug, reproduce-as-code, eval harness, audit), and the two-endpoint pointer.
- **`timeline.mdx`** — reading the timeline in the session viewer (row anatomy, coalescing rules, idle dividers), video sync (click-to-seek, scrubber markers), the detail drawer, live updates, and the markdown / JSON / ZIP exports.
- **`api.mdx`** — `GET /v1/sessions/:id/agent-traces`, the `AgentActivity` envelope and `target` shape, per-type extra fields, the live WebSocket channel, and the legacy `/agent-logs` escape hatch.

Wired into the sidebar via `content/docs/overview/meta.json` (`...agent-traces` right after `...sessions-api`).

## Notes for review

- No screenshots in these pages — that matches the convention in the rest of `overview/`, where only a handful of pages use inline images.
- API field shapes (`pointer.x`, `target.selector.css`, real event names like `doubleClick` / `change` / `keyPress`, WebSocket route at `/v1/sessions/:id/agent-traces`) were aligned with the shipped API rather than the original PR description.
- Code examples are intentionally `curl` / `fetch` only, since there's no SDK method for `agent-traces` yet.

## Test plan

- [ ] `bun run dev` and confirm the new section renders under Steel Sessions / Agent Traces in the sidebar
- [ ] Click through Overview → Timeline & exports → API and verify all internal links resolve
- [ ] Confirm the `AgentActivity` envelope table on the API page lays out cleanly (no super-tall rows from the type union)
- [ ] Spot-check the JSON and `curl` examples against the actual API response shape