### PR TITLE
fix(docs): render raw markdown from page data, not request-time fs read

### DIFF
--- a/app/[...slug]/page.tsx
+++ b/app/[...slug]/page.tsx
@@ -1,5 +1,4 @@
 //@ts-nocheck
-import fs from 'node:fs/promises';
 import defaultMdxComponents from 'fumadocs-ui/mdx';
 import matter from 'gray-matter';
 import * as lucideIcons from 'lucide-react';
@@ -44,8 +43,11 @@ export default async function Page(props: {
   }
 
   if (!page) notFound();
-  const fileContent = await fs.readFile(page.data._file.absolutePath, 'utf-8');
-  const { content: rawMarkdownContent } = matter(fileContent);
+  // Use the raw markdown bundled into page.data.content rather than reading the
+  // source file from disk at request time. The content/docs source files are not
+  // present in the serverless function sandbox, so a filesystem read throws and
+  // returns a 500 whenever the page renders outside the prerender cache.
+  const { content: rawMarkdownContent } = matter(page.data.content);
 
   const LLMContent = rawMarkdownContent
     .split('\n')


### PR DESCRIPTION
## Problem

Sharing a freshly deployed doc page (e.g. `/changelog/changelog-027`) on LinkedIn showed **500: Internal Server Error** instead of a preview. The LinkedIn Post Inspector confirmed the page itself returned an error body (title literally `500: Internal Server Error`, no OG tags found).

## Root cause

Every doc page is **SSG with `revalidate: 1h`**, so the page component re-runs on the serverless function whenever it renders outside the prerender cache — ISR revalidation, cold start, cache miss, or RSC payload regeneration.

The component read raw markdown for the `<LLMShare>` copy button via:

```ts
const fileContent = await fs.readFile(page.data._file.absolutePath, 'utf-8');
```

But `content/docs` source files are **not bundled into the function sandbox**, and the build-time absolute path doesn't resolve at runtime. So the read throws `ENOENT` → unhandled → **500**.

Why it looked intermittent: the build-time prerendered HTML is cached at the edge (returns 200 to most of us), but the **first origin hit at a cold edge POP** — exactly what LinkedIn's US crawler did on a brand-new URL — got the 500, which LinkedIn then cached as the preview.

Reproduced via the RSC render path (`curl -H 'RSC: 1'`), which intermittently returned the 500 error page while the cached HTML stayed 200.

## Fix

Use `page.data.content` — the raw markdown fumadocs already bundles into the function — instead of a request-time filesystem read. This matches how `lib/get-llm-text.ts` sources content for the working `/llms.mdx` route. No filesystem access at request time, no 500.

## Verification

- `tsc --noEmit` and Biome pass
- Full `bun run build` succeeds; all 147 changelog pages prerender
- Confirmed `/llms.mdx/changelog/changelog-027` (which uses `page.data.content`) returns 200 at runtime in production, proving that path is reliable in the function sandbox

## Follow-up after merge/deploy

Re-run the affected URLs through the LinkedIn Post Inspector to clear LinkedIn's cached 500 preview.