### PR TITLE
feat: add Reo.dev analytics pixel

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,4 +1,5 @@
 NEXT_PUBLIC_GTM_ID=
+NEXT_PUBLIC_REO_CLIENT_ID= # Reo.dev analytics client ID; set only in production so forks/previews don't pollute analytics
 LLMS_BASE_URL=
 GITHUB_APP_ID=
 GITHUB_APP_PRIVATE_KEY= # Base64 encoded GitHub App private key

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { RootProvider } from 'fumadocs-ui/provider';
 import { GeistMono } from 'geist/font/mono';
 import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
+import { ReoAnalytics } from '@/components/analytics/reo';
 import { inter, jetBrainsMono } from '@/fonts';
 import { KeyboardShortcutsProvider } from '@/hooks/use-keyboard-shortcuts';
 import { QueryProvider } from '@/providers/query-provider';
@@ -52,6 +53,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
     >
       <head />
       <body className="flex flex-col min-h-screen">
+        <ReoAnalytics />
         <QueryProvider>
           <KeyboardShortcutsProvider>
             <RootProvider

--- a/components/analytics/reo.tsx
+++ b/components/analytics/reo.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import Script from 'next/script';
+
+export function ReoAnalytics() {
+  const clientID = process.env.NEXT_PUBLIC_REO_CLIENT_ID;
+
+  if (!clientID) {
+    return null;
+  }
+
+  return (
+    <Script id="reo-init" strategy="afterInteractive">
+      {`!function(){var e,t,n;e="${clientID}",t=function(){Reo.init({clientID:"${clientID}", enableThirdPartyTracking:true})},(n=document.createElement("script")).src="https://static.reo.dev/"+e+"/reo.js",n.defer=!0,n.onload=t,document.head.appendChild(n)}();`}
+    </Script>
+  );
+}


### PR DESCRIPTION
## What

Adds the [Reo.dev](https://reo.dev) analytics tracking pixel to the docs site.

## How

- New `components/analytics/reo.tsx` — a client component that injects the Reo snippet via `next/script` (`strategy="afterInteractive"`, so it loads after hydration and doesn't block render).
- Rendered once at the top of `<body>` in `app/layout.tsx`.
- Gated behind `NEXT_PUBLIC_REO_CLIENT_ID`: renders nothing if the var is unset.

## Why env-gated

The client ID isn't a secret (it ships to the browser), but this repo is open-source. Hardcoding it would mean **every fork, preview deploy, and local `bun run dev` sends traffic into the production Reo account**, polluting analytics. Gating on the env var means only the production deployment tracks. Mirrors the existing `NEXT_PUBLIC_GTM_ID` convention.

## Deploy steps (after merge)

1. Set `NEXT_PUBLIC_REO_CLIENT_ID` in Vercel → Project Settings → Environment Variables, scoped to **Production** (add **Preview** only if preview tracking is wanted).
2. Redeploy — `NEXT_PUBLIC_*` vars are inlined at build time, so an existing deploy won't pick it up without a rebuild.
3. Verify `static.reo.dev/<id>/reo.js` loads on docs.steel.dev and **not** on forks/local.

## Notes

- `enableThirdPartyTracking: true` fires unconditionally (no consent gate), matching the provided snippet. If cookie consent is added later, the gate belongs inside `ReoAnalytics`.
- `bun run typecheck` is clean for the touched files (pre-existing `Bun`-type errors in `scripts/sync-cookbook.ts` are unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)