### PR TITLE
fix(changelog): make scheduled draft run idempotent instead of time-gated

### DIFF
--- a/.github/workflows/changelog-draft.yml
+++ b/.github/workflows/changelog-draft.yml
@@ -33,17 +33,29 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Gate scheduled run to 9 AM Toronto
+      - name: Skip scheduled run if a changelog draft PR is already open
         id: gate
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           should_run=true
 
+          # Scheduled runs are idempotent rather than time-gated: GitHub's
+          # scheduler can delay a cron by an hour or more, so we can't rely on
+          # the wall-clock execution time. Two crons fire each Friday (one per
+          # DST offset) for redundancy; whichever runs first does the work, and
+          # any later run skips once a draft PR exists. Manual dispatch always
+          # runs so drafts can be regenerated on demand.
           if [ "${{ github.event_name }}" = "schedule" ]; then
-            toronto_hour="$(TZ=America/Toronto date +%H)"
-            toronto_weekday="$(TZ=America/Toronto date +%u)"
+            open_drafts="$(gh pr list \
+              --repo "$GITHUB_REPOSITORY" \
+              --state open \
+              --json headRefName \
+              --jq '[.[] | select(.headRefName | startswith("automation/changelog-"))] | length')"
 
-            if [ "$toronto_hour" != "09" ] || [ "$toronto_weekday" != "5" ]; then
+            if [ "$open_drafts" != "0" ]; then
+              echo "Found $open_drafts open changelog draft PR(s); skipping."
               should_run=false
             fi
           fi


### PR DESCRIPTION
## Problem

The Changelog Draft workflow gated scheduled runs to `hour == "09"` Toronto. That window is only 1 hour wide, but GitHub's scheduler routinely delays cron triggers 30–60+ min. When delayed past the window the run lands in hour `10` and silently skips.

This week ([run 27022421686](https://github.com/steel-dev/docs/actions/runs/27022421686) and its sibling at 14:01 UTC) both skipped — the `0 13` cron was delayed to 14:01 UTC = 10:01 Toronto — so **no changelog was generated**. 05-29 hit the same issue (PR #44 was a manual dispatch, not the schedule).

## Fix

Replace the wall-clock gate with an **idempotency check**: a scheduled run skips only if a draft changelog PR (`automation/changelog-*`) is already open. `gh pr list` hits the API, so no checkout is needed and the skip path stays cheap.

- Immune to scheduler jitter — no dependence on execution time.
- Both Friday crons now act as redundancy: whichever fires first does the work, the other skips.
- Manual `workflow_dispatch` still always runs.