### PR TITLE
fix(changelog): emit publishedAt in generated changelog frontmatter

### DIFF
--- a/scripts/generate-changelog-draft.ts
+++ b/scripts/generate-changelog-draft.ts
@@ -503,7 +503,7 @@ function renderDraftBody(draft: DraftResult): string {
   return blocks.join('\n\n').trim();
 }
 
-function buildMdxDocument(number: number, draft: DraftResult): string {
+function buildMdxDocument(number: number, draft: DraftResult, publishedAt: string): string {
   const numberLabel = formatChangelogNumber(number);
   const imageAlt = `Announcing Changelog #${numberLabel}`;
   const frontmatter = [
@@ -513,6 +513,7 @@ function buildMdxDocument(number: number, draft: DraftResult): string {
     'llm: true',
     `image: "${CHANGELOG_PLACEHOLDER_IMAGE.src}"`,
     `imageAlt: "${imageAlt}"`,
+    `publishedAt: "${publishedAt}"`,
     '---',
     "import Image from 'next/image';",
     '',
@@ -915,7 +916,7 @@ async function main() {
   console.log(`Fetched ${commits.length} candidate commits across monitored repositories.`);
 
   const draft = await requestDraftFromModel(commits, nextNumber, windowSelection, openAiToken);
-  const mdx = buildMdxDocument(nextNumber, draft);
+  const mdx = buildMdxDocument(nextNumber, draft, windowSelection.until.slice(0, 10));
   await fs.writeFile(path.join(process.cwd(), draftPath), mdx);
   await updateChangelogMeta(slug);
   await updateChangelogLlms();


### PR DESCRIPTION
## Problem

`scripts/generate-changelog-draft.ts` never wrote a `publishedAt` field. `lib/source.ts` derives the sidebar **NEW** badge from `publishedAt` within a 10-day window (`ENABLE_GIT_NEW_DETECTION` is off), so every auto-generated changelog landed **without the badge** until someone added the date by hand — as just happened for #028.

## Fix

`buildMdxDocument` now takes a `publishedAt` arg and emits it after `imageAlt`, matching the convention in #027/#026. The value is `windowSelection.until.slice(0, 10)` — the same date already used to build the branch name, so frontmatter and branch stay consistent.

Verified: only one caller, types line up, Biome clean.