### PR TITLE
docs(seo): cross-link integrations, cookbook recipes, and topic hubs

### DIFF
--- a/content/docs/cookbook/agentkit.mdx
+++ b/content/docs/cookbook/agentkit.mdx
@@ -9,9 +9,9 @@ description: "Integrate Steel with Inngest's AgentKit framework."
 
 <RecipeQuickstart slug="agentkit" />
 
-Agent Kit is Inngest's framework for multi-agent systems: a **tool** is a typed function the model can call, an **agent** bundles a system prompt with a tool set, and a **network** groups agents so they can collaborate on a task. Agent Kit handles the routing between them and wraps each call in Inngest's `step.run` checkpoint, so a network that crashes mid-flight resumes from the last finished step.
+Agent Kit is Inngest's framework for [multi-agent systems](/cookbook/topics/agents): a **tool** is a typed function the model can call, an **agent** bundles a system prompt with a tool set, and a **network** groups agents so they can collaborate on a task. Agent Kit handles the routing between them and wraps each call in Inngest's `step.run` checkpoint, so a network that crashes mid-flight resumes from the last finished step.
 
-This starter wires Agent Kit to Steel through a single tool, `browse_hacker_news`, that opens a Steel session, drives it with Playwright over CDP, and returns structured rows.
+This starter wires Agent Kit to Steel through a single tool, `browse_hacker_news`, that opens a Steel session, drives it with Playwright over CDP, and returns structured rows. The [Inngest AgentKit integration](/integrations/agentkit) covers install and configuration.
 
 ```typescript
 const browseHackerNews = createTool({

--- a/content/docs/cookbook/agno.mdx
+++ b/content/docs/cookbook/agno.mdx
@@ -11,7 +11,7 @@ description: Integrate Steel with the Agno agent framework.
 
 Agno's primitive is `Agent(model=..., tools=[...])`. Tools are typed Python methods grouped into a `Toolkit` subclass; docstrings and type hints become the JSON schema the model sees.
 
-This recipe wraps a Steel browser in a `SteelTools` toolkit, hands it to an Agent, and lets the model drive the session by picking which method to call and filling in arguments on its own.
+This recipe wraps a Steel browser in a `SteelTools` toolkit, hands it to an Agent, and lets the model drive the session by picking which method to call and filling in arguments on its own. The [Agno integration](/integrations/agno) covers install and configuration.
 
 ```python
 tools = SteelTools(api_key=STEEL_API_KEY)

--- a/content/docs/cookbook/auth-context.mdx
+++ b/content/docs/cookbook/auth-context.mdx
@@ -79,7 +79,7 @@ Auth context fits one-shot flows where you already have a way to log in and just
 - Run an agent that signs in, snapshot at the end, hand the snapshot to the next agent in the pipeline.
 - Keep a single "warm" context in memory and spawn short-lived workers from it.
 
-If you want Steel to store credentials and handle the login itself, see [credentials](/cookbook/credentials). If you need a long-lived named identity that accumulates state across runs (history, extensions, preferences), that's a different primitive.
+If you want Steel to store credentials and handle the login itself, see [credentials](/cookbook/credentials). If you need a long-lived named identity that accumulates state across runs (history, extensions, preferences), that's a different primitive. The [authentication topic](/cookbook/topics/authentication) collects the related recipes.
 
 ## Make it yours
 

--- a/content/docs/cookbook/browser-use-captcha-auto.mdx
+++ b/content/docs/cookbook/browser-use-captcha-auto.mdx
@@ -9,7 +9,7 @@ description: Build an AI agent with browser-use and Steel that solves CAPTCHAs a
 
 <RecipeQuickstart slug="browser-use-captcha-auto" />
 
-Steel can solve CAPTCHAs inside a session without the agent lifting a finger. This recipe wires that into Browser Use: one flag at session creation, one custom tool the agent calls to block until the solver reports done. Everything else is the same perception-plan-act loop as the base [Browser Use](/cookbook/browser-use) recipe.
+Steel can solve [CAPTCHAs](/cookbook/topics/captchas) inside a session without the agent lifting a finger. This recipe wires that into Browser Use: one flag at session creation, one custom tool the agent calls to block until the solver reports done. Everything else is the same perception-plan-act loop as the base [Browser Use](/cookbook/browser-use) recipe.
 
 ```python
 session = client.sessions.create(solve_captcha=True)

--- a/content/docs/cookbook/browser-use-captcha-manual.mdx
+++ b/content/docs/cookbook/browser-use-captcha-manual.mdx
@@ -9,7 +9,7 @@ description: "Manually solve reCAPTCHA v2 using Steel's CAPTCHA API with the bro
 
 <RecipeQuickstart slug="browser-use-captcha-manual" />
 
-Steel can solve CAPTCHAs for you in the background, or it can hand you the status API and let you drive. This recipe picks the second path. The session is created with auto-solving explicitly off, a custom Browser Use tool polls `client.sessions.captchas.status()`, and it calls `client.sessions.captchas.solve()` only for the CAPTCHA type you care about. Every state transition (detected, solving, validating, solved) is yours to read and react to.
+Steel can solve [CAPTCHAs](/cookbook/topics/captchas) for you in the background, or it can hand you the status API and let you drive. This recipe picks the second path. The session is created with auto-solving explicitly off, a custom Browser Use tool polls `client.sessions.captchas.status()`, and it calls `client.sessions.captchas.solve()` only for the CAPTCHA type you care about. Every state transition (detected, solving, validating, solved) is yours to read and react to.
 
 ```python
 session = client.sessions.create(

--- a/content/docs/cookbook/browser-use.mdx
+++ b/content/docs/cookbook/browser-use.mdx
@@ -9,7 +9,7 @@ description: Integrate Steel with the browser-use framework for AI-driven web au
 
 <RecipeQuickstart slug="browser-use" />
 
-Browser Use is an agent framework: you give it an LLM, a browser, and a natural-language `task`, and it runs a perception-plan-act loop until the task is done. It doesn't need selectors or scripted steps. The model reads the page, decides the next action, and executes it against the browser you give it. The browser in this recipe is a Steel session, so the agent runs on managed cloud Chrome with stealth, proxies, and a live viewer instead of local Chromium.
+[Browser Use](/cookbook/topics/browser-use) is an agent framework: you give it an LLM, a browser, and a natural-language `task`, and it runs a perception-plan-act loop until the task is done. It doesn't need selectors or scripted steps. The model reads the page, decides the next action, and executes it against the browser you give it. The browser in this recipe is a Steel session, so the agent runs on managed cloud Chrome with stealth, proxies, and a live viewer instead of local Chromium. The [Browser Use integration](/integrations/browser-use) covers install and setup.
 
 ```python
 session = client.sessions.create()

--- a/content/docs/cookbook/chromedp.mdx
+++ b/content/docs/cookbook/chromedp.mdx
@@ -9,7 +9,7 @@ description: Use Steel with chromedp to connect over CDP, navigate to Hacker New
 
 <RecipeQuickstart slug="chromedp" />
 
-chromedp speaks the Chrome DevTools Protocol over a websocket and never shells out to a local Chrome. A Steel session exposes exactly that websocket, so `chromedp.NewRemoteAllocator` points at the remote browser and every `chromedp.Run` step executes in the cloud, behind Steel's stealth, proxies, and live viewer. No browser on your machine.
+chromedp speaks the Chrome DevTools Protocol over a websocket and never shells out to a local Chrome. A Steel session exposes exactly that websocket, so `chromedp.NewRemoteAllocator` points at the remote browser and every `chromedp.Run` step executes in the cloud, behind Steel's stealth, proxies, and live viewer. No browser on your machine, just the same [browser automation](/cookbook/topics/browser-automation) over CDP the other driver recipes use.
 
 ```go
 cdpURL := fmt.Sprintf("%s&apiKey=%s", sess.WebsocketURL, apiKey)

--- a/content/docs/cookbook/chromiumoxide.mdx
+++ b/content/docs/cookbook/chromiumoxide.mdx
@@ -9,7 +9,7 @@ description: Use Steel with chromiumoxide to connect over CDP, drive the handler
 
 <RecipeQuickstart slug="chromiumoxide" />
 
-chromiumoxide speaks the Chrome DevTools Protocol over a websocket, which is exactly what a Steel session exposes. `Browser::connect` takes the session's websocket URL and hands back a connected browser plus a `Handler`. From there you get plain async chromiumoxide: `new_page`, `content`, `get_title`, `find_elements`, `evaluate`, `screenshot`. No local Chrome, no `chromedriver`, no display.
+chromiumoxide speaks the Chrome DevTools Protocol over a websocket, which is exactly what a Steel session exposes. `Browser::connect` takes the session's websocket URL and hands back a connected browser plus a `Handler`. From there you get plain async chromiumoxide: `new_page`, `content`, `get_title`, `find_elements`, `evaluate`, `screenshot`. No local Chrome, no `chromedriver`, no display, just [browser automation](/cookbook/topics/browser-automation) over CDP against a cloud browser.
 
 The connection is one line, but it returns a tuple, and the second half is the part that trips everyone up:
 

--- a/content/docs/cookbook/claude-agent-sdk.mdx
+++ b/content/docs/cookbook/claude-agent-sdk.mdx
@@ -13,9 +13,9 @@ description: "Use Steel with the Claude Agent SDK (TypeScript) to build a tool-u
 
 <RecipeQuickstart slug="claude-agent-sdk-ts" />
 
-`@anthropic-ai/claude-agent-sdk` is the engine behind the Claude Code CLI, exposed as a Node library. You get the CLI's agent loop, hooks, subagents, MCP support, and built-in tool catalog (`Read`, `Edit`, `Bash`, `Grep`, ...) without spawning the CLI yourself.
+`@anthropic-ai/claude-agent-sdk` is the engine behind the Claude Code CLI, exposed as a Node library. You get the CLI's [agent loop](/cookbook/topics/agents), hooks, subagents, MCP support, and built-in tool catalog (`Read`, `Edit`, `Bash`, `Grep`, ...) without spawning the CLI yourself.
 
-This recipe disables those built-ins and attaches a Steel cloud browser instead. Four MCP tools (`openSession`, `navigate`, `snapshot`, `extract`) sit in front of Playwright; the agent calls them by name and streams back typed messages.
+This recipe disables those built-ins and attaches a Steel cloud browser instead; the [Claude Agent SDK integration](/integrations/claude-agent-sdk) covers install and setup. Four MCP tools (`openSession`, `navigate`, `snapshot`, `extract`) sit in front of Playwright; the agent calls them by name and streams back typed messages.
 
 ```typescript
 const navigate = tool(

--- a/content/docs/cookbook/claude-computer-use-mobile.mdx
+++ b/content/docs/cookbook/claude-computer-use-mobile.mdx
@@ -9,7 +9,7 @@ description: Claude Computer Use with Steel for autonomous task execution in mob
 
 <RecipeQuickstart slug="claude-computer-use-mobile" />
 
-Mobile-emulated Chrome, driven by Claude's computer-use tool. The agent loop is the same as the [Desktop TS](/cookbook/claude-computer-use) recipe (screenshot in, coordinate out, next screenshot back), but three things change when the surface is a phone: Steel allocates the viewport instead of you, Playwright drives the page over CDP instead of Steel's Input API, and every coordinate is clamped before it touches the browser.
+Mobile-emulated Chrome, driven by Claude's computer-use tool. The agent loop is the same as the [Desktop TS](/cookbook/claude-computer-use) recipe (screenshot in, coordinate out, next screenshot back), but three things change when the surface is a [phone](/cookbook/topics/mobile): Steel allocates the viewport instead of you, Playwright drives the page over CDP instead of Steel's Input API, and every coordinate is clamped before it touches the browser. The [Claude Computer Use integration](/integrations/claude-computer-use) covers the base setup.
 
 ## Mobile session, Playwright driver
 

--- a/content/docs/cookbook/claude-computer-use.mdx
+++ b/content/docs/cookbook/claude-computer-use.mdx
@@ -13,7 +13,7 @@ description: Connect Claude to a Steel browser session for autonomous web intera
 
 <RecipeQuickstart slug="claude-computer-use-ts" />
 
-Claude sees the screen as an image and returns concrete actions at pixel coordinates: `left_click [640, 412]`, `type "claude 4.7 opus"`, `scroll down 3`. Something has to execute those actions against a real browser and send the next screenshot back. That "something" is the agent loop in `index.ts`, and the browser is a Steel session.
+Claude sees the screen as an image and returns concrete actions at pixel coordinates: `left_click [640, 412]`, `type "claude 4.7 opus"`, `scroll down 3`. Something has to execute those actions against a real browser and send the next screenshot back. That "something" is the agent loop in `index.ts`, and the browser is a Steel session. The [Claude Computer Use integration](/integrations/claude-computer-use) covers install and setup.
 
 ## The loop
 
@@ -31,7 +31,7 @@ const response = await this.client.beta.messages.create({
 
 The tool definition declares `computer_20251124` with the viewport's `display_width_px` and `display_height_px`. Keep it consistent with the Steel session's `dimensions` (1280x768 here) or clicks land in the wrong place.
 
-`executeComputerAction` is the translation layer. Claude emits computer-use actions (`left_click`, `type`, `key`, `scroll`, `screenshot`, ...); Steel's Input API speaks a parallel vocabulary (`click_mouse`, `type_text`, `press_key`, `scroll`, `take_screenshot`):
+`executeComputerAction` is the translation layer. Claude emits [computer-use actions](/cookbook/topics/computer-use) (`left_click`, `type`, `key`, `scroll`, `screenshot`, ...); Steel's Input API speaks a parallel vocabulary (`click_mouse`, `type_text`, `press_key`, `scroll`, `take_screenshot`):
 
 ```typescript
 case "left_click":

--- a/content/docs/cookbook/convex-chat-with-page.mdx
+++ b/content/docs/cookbook/convex-chat-with-page.mdx
@@ -9,7 +9,7 @@ description: "Convex app that streams an AI agent's answer about any URL. The ag
 
 <RecipeQuickstart slug="convex-chat-with-page" />
 
-A Convex app where the user pastes a URL, asks a question, and an AI agent answers from the live page. The agent runs server-side as a `pageAgent` defined in `convex/agent.ts`, with a single tool, `scrapePage`, that fetches the URL through the `@steel-dev/convex` component and serves the markdown back in chunks. Tokens stream into the UI over websockets via `@convex-dev/agent`'s delta sync.
+A [Convex](/cookbook/topics/convex) app where the user pastes a URL, asks a question, and an [AI agent](/cookbook/topics/agents) answers from the live page. The agent runs server-side as a `pageAgent` defined in `convex/agent.ts`, with a single tool, `scrapePage`, that fetches the URL through the `@steel-dev/convex` component and serves the markdown back in chunks. Tokens stream into the UI over websockets via `@convex-dev/agent`'s delta sync.
 
 ```
 convex/

--- a/content/docs/cookbook/convex-price-watch.mdx
+++ b/content/docs/cookbook/convex-price-watch.mdx
@@ -9,7 +9,7 @@ description: Convex cron plus two parallel Steel proxy probes against claude.com
 
 <RecipeQuickstart slug="convex-price-watch" />
 
-A scheduled monitor: scrape `https://claude.com/pricing` every 10 minutes from two parallel proxy probes, store one row per (region, tier, capturedAt) in Convex, and surface tiers where the probes disagree. No LLM, no streaming. Just `@steel-dev/convex`, a cron, and a reactive dashboard.
+A scheduled monitor: scrape `https://claude.com/pricing` every 10 minutes from two parallel proxy probes, store one row per (region, tier, capturedAt) in [Convex](/cookbook/topics/convex), and surface tiers where the probes disagree. No LLM, no streaming. Just `@steel-dev/convex`, a cron, and a reactive dashboard.
 
 ```
 convex/

--- a/content/docs/cookbook/credentials.mdx
+++ b/content/docs/cookbook/credentials.mdx
@@ -13,7 +13,7 @@ description: Use the Steel Credentials API with Playwright to automate flows wit
 
 <RecipeQuickstart slug="credentials-ts" />
 
-Steel's credentials vault stores usernames and passwords against an origin. When a session opts in, Steel watches for login forms on that origin and fills them for you. No login code in your automation, no plaintext passwords in env vars, no custom storage for cookies.
+Steel's credentials vault stores usernames and passwords against an origin. When a session opts in, Steel watches for login forms on that origin and fills them for you. No login code in your automation, no plaintext passwords in env vars, no custom storage for cookies. It's one of Steel's [authentication](/cookbook/topics/authentication) primitives.
 
 Two API calls wire it up. First, save the credential once:
 

--- a/content/docs/cookbook/crewai.mdx
+++ b/content/docs/cookbook/crewai.mdx
@@ -9,7 +9,7 @@ description: Integrate Steel with the CrewAI multi-agent framework.
 
 <RecipeQuickstart slug="crewai" />
 
-CrewAI composes LLM work out of three primitives: an `Agent` (role, goal, tools), a `Task` (description + expected output), and a `Crew` that runs them in order. This recipe wires two agents, a `researcher` and a `reporting_analyst`, to a single custom tool that calls Steel's scrape API. The researcher gathers sources; the analyst turns them into `report.md`.
+CrewAI composes LLM work out of three primitives: an `Agent` (role, goal, tools), a `Task` (description + expected output), and a `Crew` that runs them in order. This recipe wires two [agents](/cookbook/topics/agents), a `researcher` and a `reporting_analyst`, to a single custom tool that calls Steel's scrape API. The researcher gathers sources; the analyst turns them into `report.md`. The [CrewAI integration](/integrations/crewai) covers install and setup.
 
 ```python
 @agent

--- a/content/docs/cookbook/deep-research.mdx
+++ b/content/docs/cookbook/deep-research.mdx
@@ -13,9 +13,9 @@ description: Lead orchestrator dispatches parallel researcher subagents, each dr
 
 <RecipeQuickstart slug="deep-research-ts" />
 
-`@anthropic-ai/claude-agent-sdk` exposes typed `AgentDefinition` values that you pass through the `agents` field on `query()`. The lead agent invokes them through the built-in `Agent` tool. Multiple `Agent` calls fired in a single assistant turn run in parallel, and each subagent starts in fresh context.
+`@anthropic-ai/claude-agent-sdk` exposes typed `AgentDefinition` values that you pass through the `agents` field on `query()`. The lead agent invokes them through the built-in `Agent` tool. Multiple `Agent` calls fired in a single assistant turn run in parallel, and each [subagent](/cookbook/topics/subagents) starts in fresh context.
 
-This recipe wires that pattern to Steel. The lead "orchestrator" never opens a browser. It splits a research question into focused sub-questions, hands one to each `researcher` subagent, and synthesizes their cited findings into a Markdown report. Every researcher gets its own Steel session, so three browsers run side by side without stomping on each other's address bar.
+This recipe wires that pattern to Steel, built on the [Claude Agent SDK integration](/integrations/claude-agent-sdk). The lead "orchestrator" never opens a browser. It splits a research question into focused sub-questions, hands one to each `researcher` subagent, and synthesizes their cited findings into a Markdown report. Every researcher gets its own Steel session, so three browsers run side by side without stomping on each other's address bar.
 
 ```ts
 const researcher: AgentDefinition = {

--- a/content/docs/cookbook/eino.mdx
+++ b/content/docs/cookbook/eino.mdx
@@ -9,7 +9,7 @@ description: "Use Steel with the ByteDance Eino framework to build a ReAct agent
 
 <RecipeQuickstart slug="eino" />
 
-[Eino](https://www.cloudwego.io/docs/eino/) is ByteDance's LLM application framework for Go. Its `flow/agent/react` package ships a prebuilt ReAct agent: give it a tool-calling model and a set of tools, and it runs the reason-act loop for you. This recipe gives that agent two tools backed by Steel's Scrape API and points it at a news front page to write a short research briefing.
+[Eino](https://www.cloudwego.io/docs/eino/) is ByteDance's LLM application framework for Go. Its `flow/agent/react` package ships a prebuilt [ReAct agent](/cookbook/topics/agents): give it a tool-calling model and a set of tools, and it runs the reason-act loop for you. This recipe gives that agent two tools backed by Steel's Scrape API and points it at a news front page to write a short research briefing.
 
 Unlike a CDP-driven recipe, there is no browser session to open or release here. `client.Scrape` runs a browser on Steel's side, fetches the page, and returns clean Markdown plus the page's links. The agent reads pages the way an LLM wants to read them (as text, not pixels), so the tools are plain HTTP calls and the whole program is stateless between turns.
 

--- a/content/docs/cookbook/extensions.mdx
+++ b/content/docs/cookbook/extensions.mdx
@@ -13,7 +13,7 @@ description: Use the Steel Extensions API with Playwright to upload and run brow
 
 <RecipeQuickstart slug="extensions-ts" />
 
-Steel sessions launch a clean Chrome with nothing installed. The Extensions API lets you upload a Chrome extension once, get back an ID, and attach it to any future session via `extensionIds` on `sessions.create()`. Content scripts and background workers load before your first `page.goto`, so the extension has already rewritten the DOM by the time Playwright observes it.
+Steel sessions launch a clean Chrome with nothing installed. The [Extensions API](/cookbook/topics/steel-apis) lets you upload a Chrome extension once, get back an ID, and attach it to any future session via `extensionIds` on `sessions.create()`. Content scripts and background workers load before your first `page.goto`, so the extension has already rewritten the DOM by the time Playwright observes it.
 
 ```typescript
 const extensionExists = (await client.extensions.list()).extensions.find(

--- a/content/docs/cookbook/files.mdx
+++ b/content/docs/cookbook/files.mdx
@@ -13,7 +13,7 @@ description: Use the Steel Files API with Playwright to automate file uploads an
 
 <RecipeQuickstart slug="files-ts" />
 
-Every Steel session ships with a scoped filesystem inside the session VM. `client.sessions.files` exposes methods to move bytes across the boundary between your machine and that sandbox. This recipe uses `upload` to push a local CSV into the session, hands the resulting path to a remote `<input type="file">` over CDP, and lets the browser render a chart against it.
+Every Steel session ships with a scoped filesystem inside the session VM. `client.sessions.files` exposes methods to move bytes across the boundary between your machine and that sandbox. This recipe uses `upload` to push a local CSV into the session, hands the resulting path to a remote `<input type="file">` over CDP, and lets the browser render a chart against it. It's one of Steel's [session APIs](/cookbook/topics/steel-apis).
 
 ```typescript
 const uploadedFile = await client.sessions.files.upload(session.id, {

--- a/content/docs/cookbook/gemini-computer-use.mdx
+++ b/content/docs/cookbook/gemini-computer-use.mdx
@@ -13,9 +13,9 @@ description: "Connect Google's Gemini Computer Use to a Steel browser session fo
 
 <RecipeQuickstart slug="gemini-computer-use-ts" />
 
-Gemini exposes computer use as a built-in tool type, not a hand-written schema. You set `config.tools = [{ computerUse: { environment: Environment.ENVIRONMENT_BROWSER } }]` on a `generateContent` call and the model plans against a fixed action vocabulary (`click_at`, `type_text_at`, `navigate`, `scroll_document`, `search`, `drag_and_drop`, `key_combination`, ...) with coordinates in a normalized 0-1000 grid.
+Gemini exposes [computer use](/cookbook/topics/computer-use) as a built-in tool type, not a hand-written schema. You set `config.tools = [{ computerUse: { environment: Environment.ENVIRONMENT_BROWSER } }]` on a `generateContent` call and the model plans against a fixed action vocabulary (`click_at`, `type_text_at`, `navigate`, `scroll_document`, `search`, `drag_and_drop`, `key_combination`, ...) with coordinates in a normalized 0-1000 grid.
 
-The model defaults to `gemini-3-flash-preview`. Conversation state lives entirely on your side, appended to `this.contents` turn by turn.
+The model defaults to `gemini-3-flash-preview`. Conversation state lives entirely on your side, appended to `this.contents` turn by turn. The [Gemini Computer Use integration](/integrations/gemini-computer-use) covers install and setup.
 
 ## Coordinates and action mapping
 

--- a/content/docs/cookbook/genkit.mdx
+++ b/content/docs/cookbook/genkit.mdx
@@ -44,7 +44,7 @@ type extractInput struct {
 
 ## Two ways to read a page
 
-The tools cover the two access patterns a browsing agent needs:
+The tools cover the two access patterns a [browsing agent](/cookbook/topics/agents) needs:
 
 - `navigate` + `extract` drive one live chromedp tab attached to the Steel session over CDP. `extract` takes a row selector plus a field-per-column list and runs the whole pull inside a single `chromedp.Evaluate`. Serial CDP round-trips to a cloud browser run about 200 to 300 ms each, so collapsing N rows by M fields into one evaluate keeps a page read under a second instead of stacking dozens of trips.
 - `scrape` calls `client.Scrape` and returns clean Markdown for a URL without touching the tab. It is the reliable path when the agent just needs an article's text, and it sidesteps selector guesswork entirely.

--- a/content/docs/cookbook/google-adk.mdx
+++ b/content/docs/cookbook/google-adk.mdx
@@ -13,7 +13,7 @@ description: "Use Steel with Google's Agent Development Kit (ADK) for Go to buil
 
 <RecipeQuickstart slug="google-adk-ts" />
 
-[Google ADK](https://adk.dev/) (`@google/adk`) is Google's Agent Development Kit. You build an `LlmAgent` with a Gemini model, `instruction`, and a list of `FunctionTool`s, then hand it to a `Runner`. The runner owns the loop: it appends your message to a session, calls the model, dispatches tool calls, feeds results back, and yields an async stream of `Event`s until the agent produces its final answer.
+[Google ADK](https://adk.dev/) (`@google/adk`) is Google's Agent Development Kit. You build an `LlmAgent` with a Gemini model, `instruction`, and a list of `FunctionTool`s, then hand it to a `Runner`. The runner owns the loop: it appends your message to a session, calls the model, dispatches tool calls, feeds results back, and yields an async stream of `Event`s until the [agent](/cookbook/topics/agents) produces its final answer.
 
 This recipe wires that tool layer to a Steel cloud browser. Three `FunctionTool`s in `index.ts` (`navigate`, `snapshot`, `extract`) drive a single Playwright page over CDP. The Steel session opens once in `main()` before the runner starts, so the tools close over a live `page` rather than spinning up a browser per call. Demo task: read the front page of Hacker News and return the top 5 stories as JSON.
 

--- a/content/docs/cookbook/headless-chrome.mdx
+++ b/content/docs/cookbook/headless-chrome.mdx
@@ -9,7 +9,7 @@ description: Use Steel with headless_chrome, the synchronous Rust equivalent of 
 
 <RecipeQuickstart slug="headless-chrome" />
 
-headless_chrome is the Rust equivalent of Puppeteer: a high-level, synchronous wrapper over the Chrome DevTools Protocol. `Browser::connect` takes a websocket URL and returns a connected browser, which is all a Steel session is. There is no event loop to drive and no async runtime in the browser code itself: `new_tab`, `navigate_to`, `find_elements`, and `capture_screenshot` block until they return, the way the Node original does.
+headless_chrome is the Rust equivalent of Puppeteer: a high-level, synchronous wrapper over the Chrome DevTools Protocol. `Browser::connect` takes a websocket URL and returns a connected browser, which is all a Steel session is. There is no event loop to drive and no async runtime in the browser code itself: `new_tab`, `navigate_to`, `find_elements`, and `capture_screenshot` block until they return, the way the Node original does. It is the same cloud [browser automation](/cookbook/topics/browser-automation) as the other CDP recipes, in synchronous Rust.
 
 ```rust
 let browser = Browser::connect(cdp_url)?;

--- a/content/docs/cookbook/langchaingo.mdx
+++ b/content/docs/cookbook/langchaingo.mdx
@@ -9,7 +9,7 @@ description: "Use Steel with LangChainGo's zero-shot ReAct (MRKL) agent and a st
 
 <RecipeQuickstart slug="langchaingo" />
 
-[LangChainGo](https://github.com/tmc/langchaingo) is the Go port of LangChain: LLM wrappers, chains, and agents that loop over tools until they reach an answer. This recipe gives a LangChainGo agent one tool backed by Steel's `scrape` endpoint, so the model reads pages as clean Markdown and never touches a browser library or CDP. The agent runs on Anthropic (`claude-sonnet-4-6`) through a zero-shot ReAct (MRKL) executor.
+[LangChainGo](https://github.com/tmc/langchaingo) is the Go port of LangChain: LLM wrappers, chains, and agents that loop over tools until they reach an answer. This recipe gives a LangChainGo [browser agent](/cookbook/topics/agents) one tool backed by Steel's `scrape` endpoint, so the model reads pages as clean Markdown and never touches a browser library or CDP. The agent runs on Anthropic (`claude-sonnet-4-6`) through a zero-shot ReAct (MRKL) executor.
 
 LangChainGo's `tools.Tool` interface is deliberately small. A tool is a name, a description, and a `Call` that takes a string and returns a string:
 

--- a/content/docs/cookbook/langgraph.mdx
+++ b/content/docs/cookbook/langgraph.mdx
@@ -9,9 +9,9 @@ description: Use Steel with LangGraph to build a typed browser agent with an exp
 
 <RecipeQuickstart slug="langgraph" />
 
-[LangGraph](https://langchain-ai.github.io/langgraph/) builds agents as state machines: nodes do work, edges route control, and the agent loop is something you compose explicitly. LangChain ships the model wrapper (`ChatAnthropic`) and the `@tool` decorator; LangGraph ships the graph runtime, plus prebuilt `ToolNode` and `tools_condition` helpers.
+[LangGraph](https://langchain-ai.github.io/langgraph/) builds agents as state machines: nodes do work, edges route control, and the agent loop is something you compose explicitly. LangChain ships the model wrapper (`ChatAnthropic`) and the `@tool` decorator; LangGraph ships the graph runtime, plus prebuilt `ToolNode` and `tools_condition` helpers. Steel's [LangGraph integration](/integrations/langgraph) covers the same setup on its own.
 
-This recipe is a four-tool browser agent: `open_session`, `navigate`, `snapshot`, `extract`. Each tool drives a Steel cloud session over Playwright. The graph has three nodes (`agent`, `tools`, `format`) and runs against `github.com/trending/python`, returning a Pydantic-validated `FinalReport`.
+This recipe is a four-tool [browser agent](/cookbook/topics/agents): `open_session`, `navigate`, `snapshot`, `extract`. Each tool drives a Steel cloud session over Playwright. The graph has three nodes (`agent`, `tools`, `format`) and runs against `github.com/trending/python`, returning a Pydantic-validated `FinalReport`.
 
 ```python
 graph = StateGraph(State)

--- a/content/docs/cookbook/magnitude.mdx
+++ b/content/docs/cookbook/magnitude.mdx
@@ -9,7 +9,7 @@ description: Use Steel with Magnitude for AI-powered browser automation.
 
 <RecipeQuickstart slug="magnitude" />
 
-Magnitude grew out of end-to-end testing and kept the bias: an agent loop that narrates each turn, a CDP-level browser hookup, and LLM-backed primitives designed to intermix navigation, action, and typed readback. `startBrowserAgent()` hands you a `BrowserAgent` with a small surface this recipe exercises:
+Magnitude grew out of end-to-end testing and kept the bias: an [agent loop](/cookbook/topics/agents) that narrates each turn, a CDP-level browser hookup, and LLM-backed primitives designed to intermix navigation, action, and typed readback. Steel's [Magnitude integration](/integrations/magnitude) covers the same setup on its own. `startBrowserAgent()` hands you a `BrowserAgent` with a small surface this recipe exercises:
 
 - `agent.extract(instruction, schema)`: describe what to pull off the page, pass a Zod schema, get a typed result.
 - `agent.act(instruction)`: describe an interaction in natural language. The agent plans, clicks, types, retries.

--- a/content/docs/cookbook/mastra.mdx
+++ b/content/docs/cookbook/mastra.mdx
@@ -9,9 +9,9 @@ description: Use Steel with Mastra to build a typed browser agent with the Mastr
 
 <RecipeQuickstart slug="mastra" />
 
-[Mastra](https://mastra.ai/) is a TypeScript framework that wraps the Vercel AI SDK with typed tools, a model router, and a built-in Studio playground for chatting with your agents and inspecting traces.
+[Mastra](https://mastra.ai/) is a TypeScript framework that wraps the Vercel AI SDK with typed tools, a model router, and a built-in Studio playground for chatting with your agents and inspecting traces. Steel's [Mastra integration](/integrations/mastra) covers the same setup on its own.
 
-This recipe is a four-tool browser agent: `open-session`, `navigate`, `snapshot`, `extract`. Each tool drives a Steel cloud session over Playwright. The agent runs against `github.com/trending/python` and returns a Zod-validated `FinalReport`.
+This recipe is a four-tool [browser agent](/cookbook/topics/agents): `open-session`, `navigate`, `snapshot`, `extract`. Each tool drives a Steel cloud session over Playwright. The agent runs against `github.com/trending/python` and returns a Zod-validated `FinalReport`.
 
 ```typescript
 const researchAgent = new Agent({

--- a/content/docs/cookbook/mcp.mdx
+++ b/content/docs/cookbook/mcp.mdx
@@ -13,7 +13,7 @@ description: Build a Model Context Protocol server in Go with the official SDK a
 
 <RecipeQuickstart slug="mcp-ts" />
 
-This is a [Model Context Protocol](https://modelcontextprotocol.io) server that hands any MCP client a Steel cloud browser to drive. It uses the official [TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk) and drives the browser with Playwright over CDP through `connectOverCDP`, so there is no local Chrome to launch. The server carries no model key of its own: the client supplies the model, this process owns the cloud session.
+This is a [Model Context Protocol](https://modelcontextprotocol.io) server that hands any [MCP client](/cookbook/topics/mcp) a Steel cloud browser to drive. It uses the official [TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk) and drives the browser with Playwright over CDP through `connectOverCDP`, so there is no local Chrome to launch. The server carries no model key of its own: the client supplies the model, this process owns the cloud session.
 
 Five tools make up the surface. `create_session` opens a Steel session and returns its id; `navigate`, `extract`, and `screenshot` take that id and act on the browser; `release_session` closes it.
 

--- a/content/docs/cookbook/microsoft-agent-framework.mdx
+++ b/content/docs/cookbook/microsoft-agent-framework.mdx
@@ -11,7 +11,7 @@ description: Use Steel with Microsoft Agent Framework 1.0 (the successor to Auto
 
 [Microsoft Agent Framework](https://learn.microsoft.com/en-us/agent-framework/overview/) is Microsoft's 1.0 agent runtime (Python + .NET), the successor to AutoGen and Semantic Kernel. Provider-agnostic chat clients, function tools as plain Python callables, and built-in MCP / A2A interop.
 
-This starter wires a Steel browser into the framework's `@tool` decorator pattern and points the agent at GitHub Trending.
+This starter wires a Steel browser into the framework's `@tool` decorator pattern and points the [agent](/cookbook/topics/agents) at GitHub Trending.
 
 ```python
 from agent_framework import Agent, tool

--- a/content/docs/cookbook/notte.mdx
+++ b/content/docs/cookbook/notte.mdx
@@ -9,7 +9,7 @@ description: "Control browsers with AI using Steel's infrastructure and Notte's 
 
 <RecipeQuickstart slug="notte" />
 
-Notte builds its agent on top of a perception layer. Each step, `notte.Session` flattens the live DOM into a compact action space (labeled interactive elements, form fields, section headings) and hands that structured view to the reasoning model. The model picks an action by id, Notte translates it back into a browser command.
+Notte builds its [agent](/cookbook/topics/agents) on top of a perception layer. Each step, `notte.Session` flattens the live DOM into a compact action space (labeled interactive elements, form fields, section headings) and hands that structured view to the reasoning model. The model picks an action by id, Notte translates it back into a browser command. Steel's [Notte integration](/integrations/notte) covers the same setup on its own.
 
 This recipe points that loop at a Steel session instead of a locally-launched browser.
 

--- a/content/docs/cookbook/openai-agents.mdx
+++ b/content/docs/cookbook/openai-agents.mdx
@@ -13,7 +13,7 @@ description: Use Steel with the OpenAI Agents SDK for TypeScript to build typed,
 
 <RecipeQuickstart slug="openai-agents-ts" />
 
-The [OpenAI Agents SDK](https://openai.github.io/openai-agents-js/) (`@openai/agents`) is a small runtime for agentic loops. You define an `Agent` with `instructions`, a `model`, `tools`, and an `outputType`. You call `run(agent, prompt)`. The SDK handles "pick a tool, call it, feed the result back, repeat" and validates the final message against your schema.
+The [OpenAI Agents SDK](https://openai.github.io/openai-agents-js/) (`@openai/agents`) is a small runtime for [agentic loops](/cookbook/topics/agents). You define an `Agent` with `instructions`, a `model`, `tools`, and an `outputType`. You call `run(agent, prompt)`. The SDK handles "pick a tool, call it, feed the result back, repeat" and validates the final message against your schema. Steel's [OpenAI Agents SDK integration](/integrations/openai-agents-sdk) covers the same pairing on its own.
 
 This recipe turns the tool layer into a Steel cloud browser. Four `tool()` wrappers in `index.ts` (`openSession`, `navigate`, `snapshot`, `extract`) shuttle CDP calls between the agent and Playwright. Demo task: scan `github.com/trending/python` and return the top 3 AI/ML repos as a validated `FinalReport`.
 

--- a/content/docs/cookbook/openai-computer-use.mdx
+++ b/content/docs/cookbook/openai-computer-use.mdx
@@ -13,7 +13,7 @@ description: "Connect OpenAI's Computer Use Assistant to a Steel browser session
 
 <RecipeQuickstart slug="openai-computer-use-ts" />
 
-OpenAI's computer-use model ships as a single tool declaration: `{ type: "computer" }`. You hand it to the Responses API, send a screenshot, and the model returns `computer_call` items with actions like `click`, `type`, `keypress`, `scroll`. Your job is to execute them against a real browser, capture the next screenshot, and feed it back.
+OpenAI's [computer-use](/cookbook/topics/computer-use) model ships as a single tool declaration: `{ type: "computer" }`. You hand it to the Responses API, send a screenshot, and the model returns `computer_call` items with actions like `click`, `type`, `keypress`, `scroll`. Your job is to execute them against a real browser, capture the next screenshot, and feed it back. Steel's [OpenAI Computer Use integration](/integrations/openai-computer-use) covers the same loop as a guide.
 
 ## The loop
 

--- a/content/docs/cookbook/playwright.mdx
+++ b/content/docs/cookbook/playwright.mdx
@@ -13,7 +13,7 @@ description: Use Steel with Playwright in TypeScript for cloud browser automatio
 
 <RecipeQuickstart slug="playwright-ts" />
 
-Playwright exposes `chromium.connectOverCDP()`, which attaches to any Chrome speaking the Chrome DevTools Protocol. Steel sessions expose one over a websocket. Connect them and your local code drives a remote browser with stealth, proxies, and a live viewer. No Chrome on your machine required.
+Playwright exposes `chromium.connectOverCDP()`, which attaches to any Chrome speaking the Chrome DevTools Protocol. Steel sessions expose one over a websocket. Connect them and your local code [drives a remote browser](/cookbook/topics/browser-automation) with stealth, proxies, and a live viewer. No Chrome on your machine required. Steel's [Playwright integration](/integrations/playwright) covers the same connection as a guide.
 
 ```typescript
 session = await client.sessions.create();

--- a/content/docs/cookbook/profiles.mdx
+++ b/content/docs/cookbook/profiles.mdx
@@ -13,7 +13,7 @@ description: Maintain authenticated sessions across Steel browser instances usin
 
 <RecipeQuickstart slug="profiles-ts" />
 
-A Steel profile is a named, long-lived browser identity. It holds everything a real Chrome user profile accumulates over time: cookies, localStorage, IndexedDB, history, installed extensions, autofill, site permissions. Every session you attach to the profile starts where the last one left off, and writes the user data directory back on release.
+A Steel profile is a named, long-lived browser identity. It holds everything a real Chrome user profile accumulates over time: cookies, localStorage, IndexedDB, history, installed extensions, autofill, site permissions. Every session you attach to the profile starts where the last one left off, and writes the user data directory back on release. Profiles are one of Steel's [authentication](/cookbook/topics/authentication) options for starting a browser already signed in.
 
 Two options on `sessions.create` wire it up. On the first run, mint a fresh profile:
 

--- a/content/docs/cookbook/pydantic-ai.mdx
+++ b/content/docs/cookbook/pydantic-ai.mdx
@@ -9,9 +9,9 @@ description: Use Steel with Pydantic AI to build typed, provider-agnostic browse
 
 <RecipeQuickstart slug="pydantic-ai" />
 
-[Pydantic AI](https://ai.pydantic.dev/) is the Pydantic team's agent framework. It's provider-agnostic and reuses Pydantic models for tool arguments and final outputs.
+[Pydantic AI](https://ai.pydantic.dev/) is the Pydantic team's agent framework. It's provider-agnostic and reuses Pydantic models for tool arguments and final outputs. Steel's [Pydantic AI integration](/integrations/pydantic-ai) covers the same setup on its own.
 
-This starter wires a Steel browser into Pydantic AI's dependency-injection pattern and points the agent at GitHub Trending.
+This starter wires a Steel browser into Pydantic AI's dependency-injection pattern and points the [agent](/cookbook/topics/agents) at GitHub Trending.
 
 ```python
 from pydantic_ai import Agent, RunContext

--- a/content/docs/cookbook/restate-agent.mdx
+++ b/content/docs/cookbook/restate-agent.mdx
@@ -13,7 +13,7 @@ description: Build a Restate Virtual Object in TypeScript that uses durable Open
 
 <RecipeQuickstart slug="restate-agent-ts" />
 
-This recipe runs a Restate Virtual Object named `ResearchSession`. Its `answer` handler keeps scraped observations in object state, wraps OpenAI planning calls in durable `ctx.run` steps, and calls Steel's `scrape` API as the browser tool. If the service process crashes after Steel has fetched a page, Restate replays the journal entry instead of scraping the same page again.
+This recipe runs a [Restate](/cookbook/topics/restate) Virtual Object named `ResearchSession`. Its `answer` handler keeps scraped observations in object state, wraps OpenAI planning calls in durable `ctx.run` steps, and calls Steel's `scrape` API as the browser tool. If the service process crashes after Steel has fetched a page, Restate replays the journal entry instead of scraping the same page again.
 
 The agent loop is deliberately small:
 

--- a/content/docs/cookbook/rig.mdx
+++ b/content/docs/cookbook/rig.mdx
@@ -9,7 +9,7 @@ description: Use Steel with rig to build an agent that drives a cloud browser ov
 
 <RecipeQuickstart slug="rig" />
 
-[rig](https://docs.rs/rig-core) is a Rust framework for LLM applications: you define tools as trait impls, hand them to an `Agent`, and call `prompt`, which loops the model over those tools until it produces an answer. This recipe gives the agent two tools backed by a real Chrome running in the cloud through Steel, driven over CDP with [chromiumoxide](https://docs.rs/chromiumoxide). The model navigates and reads the live DOM itself instead of receiving pre-scraped text, so it can follow links and work on pages that only exist after JavaScript runs.
+[rig](https://docs.rs/rig-core) is a Rust framework for LLM applications: you define tools as trait impls, hand them to an `Agent`, and call `prompt`, which loops the model over those tools until it produces an answer. This recipe gives the [agent](/cookbook/topics/agents) two tools backed by a real Chrome running in the cloud through Steel, driven over CDP with [chromiumoxide](https://docs.rs/chromiumoxide). The model navigates and reads the live DOM itself instead of receiving pre-scraped text, so it can follow links and work on pages that only exist after JavaScript runs.
 
 Each tool is a struct that owns a `chromiumoxide::Page` and implements rig's `Tool` trait:
 

--- a/content/docs/cookbook/rod.mdx
+++ b/content/docs/cookbook/rod.mdx
@@ -9,7 +9,7 @@ description: "Use Steel with Rod's fluent, chainable API to connect over CDP and
 
 <RecipeQuickstart slug="rod" />
 
-Rod talks the Chrome DevTools Protocol directly and exposes it through a chainable, panic-on-error API. A Steel session is a Chrome instance reachable over a websocket, so `ControlURL` is the only seam you need: hand Rod the session's websocket URL with your key appended, and the rest of your code is ordinary Rod against a browser that runs in Steel's cloud with stealth, proxies, and a live viewer. Nothing about the queries below knows or cares that the browser is remote.
+Rod talks the Chrome DevTools Protocol directly and exposes it through a chainable, panic-on-error API. A Steel session is a Chrome instance reachable over a websocket, so `ControlURL` is the only seam you need: hand Rod the session's websocket URL with your key appended, and the rest of your code is ordinary Rod against a browser that runs in Steel's cloud with stealth, proxies, and a live viewer. Nothing about the queries below knows or cares that the browser is remote. It is the same connect-over-CDP [browser automation](/cookbook/topics/browser-automation) the rest of the cookbook uses.
 
 ```go
 cdpURL := fmt.Sprintf("%s&apiKey=%s", session.WebsocketURL, apiKey)

--- a/content/docs/cookbook/scrape.mdx
+++ b/content/docs/cookbook/scrape.mdx
@@ -25,7 +25,7 @@ const scraped = await client.scrape({
 const markdown = scraped.content.markdown ?? "";
 ```
 
-`scrape()` runs the fetch and the cleanup on Steel's side, so there is no session to create, connect to, or release. One HTTP call in, structured content out. The same `client.screenshot()` and `client.pdf()` calls render the same page two other ways.
+`scrape()` runs the fetch and the cleanup on Steel's side, so there is no session to create, connect to, or release. One HTTP call in, structured content out. `scrape` is one of the direct [Steel API](/cookbook/topics/steel-apis) endpoints, with no browser session to manage. The same `client.screenshot()` and `client.pdf()` calls render the same page two other ways.
 
 ## Markdown for model context
 

--- a/content/docs/cookbook/selenium.mdx
+++ b/content/docs/cookbook/selenium.mdx
@@ -30,7 +30,7 @@ class CustomRemoteConnection(RemoteConnection):
 
 `get_remote_connection_headers` runs on every outbound request. Selenium has no persistent connection to keep alive; the two headers ride along with each command. That's the integration. After the driver is wired, the rest is vanilla Selenium 4.
 
-One requirement: create the session with `is_selenium=True`. Steel provisions a WebDriver-compatible node for those sessions; without the flag you get a CDP browser that Selenium cannot drive.
+One requirement: create the session with `is_selenium=True`. Steel provisions a WebDriver-compatible node for those sessions; without the flag you get a CDP browser that Selenium cannot drive. Steel's [Selenium integration](/integrations/selenium) covers the same setup on its own.
 
 ```python
 session = client.sessions.create(is_selenium=True)

--- a/content/docs/cookbook/stagehand.mdx
+++ b/content/docs/cookbook/stagehand.mdx
@@ -18,7 +18,7 @@ Stagehand replaces brittle selectors with two LLM-backed primitives:
 - `stagehand.extract(instruction, schema)`: describe what you want, pass a Zod schema, get typed data back.
 - `stagehand.act(instruction)`: describe an action in natural language, Stagehand figures out the click / type / scroll.
 
-Both run against a Steel session over CDP, so Stagehand handles the reasoning and Steel handles the browser (stealth, proxies, live viewer).
+Both run against a Steel session over CDP, so Stagehand handles the reasoning and Steel handles the browser (stealth, proxies, live viewer). Steel's [Stagehand integration](/integrations/stagehand) covers the same wiring on its own.
 
 ```typescript
 stagehand = new Stagehand({

--- a/content/docs/cookbook/swiftide.mdx
+++ b/content/docs/cookbook/swiftide.mdx
@@ -9,7 +9,7 @@ description: "Use Steel with Swiftide to build an agent whose tool reads the web
 
 <RecipeQuickstart slug="swiftide" />
 
-[Swiftide](https://swiftide.rs) is a Rust framework for LLM applications: indexing pipelines, query pipelines, and agents that loop over tool calls until they reach an answer. This recipe builds an agent whose only tool reads the web through Steel's `scrape` endpoint, so the model works from clean Markdown instead of raw HTML and never touches a browser library or CDP.
+[Swiftide](https://swiftide.rs) is a Rust framework for LLM applications: indexing pipelines, query pipelines, and agents that loop over tool calls until they reach an answer. This recipe builds an [agent](/cookbook/topics/agents) whose only tool reads the web through Steel's `scrape` endpoint, so the model works from clean Markdown instead of raw HTML and never touches a browser library or CDP.
 
 The agent runs on Anthropic (`claude-sonnet-4-6`) and the tool is a `#[derive(Tool)]` struct that owns the Steel client:
 

--- a/content/docs/cookbook/temporal-browser-workflow.mdx
+++ b/content/docs/cookbook/temporal-browser-workflow.mdx
@@ -13,7 +13,7 @@ description: Build a Temporal TypeScript Workflow that schedules retryable Steel
 
 <RecipeQuickstart slug="temporal-browser-workflow-ts" />
 
-This recipe runs a Temporal Workflow named `browserWorkflow`. The Workflow stays deterministic: it clamps small inputs, loops over URLs, and delegates each Steel scrape plus screenshot to the `capturePage` Activity. The Activity writes Markdown and PNG artifacts locally, then returns the compact page summary recorded in workflow history.
+This recipe runs a [Temporal](/cookbook/topics/temporal) Workflow named `browserWorkflow`. The Workflow stays deterministic: it clamps small inputs, loops over URLs, and delegates each Steel scrape plus screenshot to the `capturePage` Activity. The Activity writes Markdown and PNG artifacts locally, then returns the compact page summary recorded in workflow history.
 
 The retry boundary lives on the Activity proxy in `workflows.ts`:
 

--- a/content/docs/cookbook/topics/browser-automation.mdx
+++ b/content/docs/cookbook/topics/browser-automation.mdx
@@ -15,3 +15,9 @@ description: "Drive a cloud browser with familiar automation libraries: Playwrig
 <RecipeCard slug="puppeteer" title={"Automate a cloud browser with Puppeteer"} description={"Use Steel with Puppeteer in TypeScript for cloud browser automation."} topics={['Browser automation']} languages={['TypeScript']} date="2024-11-19" />
 <RecipeCard slug="selenium" title={"Automate a cloud browser with Selenium"} description={"Use Steel with Selenium in Python for cloud browser automation."} topics={['Browser automation']} languages={['Python']} date="2024-11-19" />
 </RecipeGrid>
+
+## Related integrations
+
+- [Steel + Playwright](/integrations/playwright): Drive a Steel browser with Playwright over CDP.
+- [Steel + Puppeteer](/integrations/puppeteer): Drive a Steel browser with Puppeteer over CDP.
+- [Steel + Selenium](/integrations/selenium): Drive a Steel browser with Selenium.

--- a/content/docs/cookbook/topics/browser-use.mdx
+++ b/content/docs/cookbook/topics/browser-use.mdx
@@ -8,3 +8,7 @@ description: Agent recipes built on the browser-use framework.
 <RecipeCard slug="browser-use" title={"Build a browser agent with Browser Use"} description={"Integrate Steel with the browser-use framework for AI-driven web automation."} topics={['Agents', 'Browser Use']} languages={['Python']} date="2025-02-20" />
 <RecipeCard slug="browser-use-captcha-auto" title={"Solve CAPTCHAs automatically in a Browser Use agent"} description={"Build an AI agent with browser-use and Steel that solves CAPTCHAs automatically."} topics={['Agents', 'Browser Use', 'Captchas']} languages={['Python']} date="2025-02-20" />
 </RecipeGrid>
+
+## Related integrations
+
+- [Steel + Browser Use](/integrations/browser-use): Set up Steel with the browser-use framework.

--- a/content/docs/cookbook/topics/captchas.mdx
+++ b/content/docs/cookbook/topics/captchas.mdx
@@ -7,3 +7,8 @@ description: "Recipes that handle CAPTCHA challenges using Steel's CAPTCHA API."
 <RecipeCard slug="browser-use-captcha-manual" title={"Solve reCAPTCHA v2 manually with Browser Use"} description={"Manually solve reCAPTCHA v2 using Steel's CAPTCHA API with the browser-use framework."} topics={['Agents', 'Browser Use', 'Captchas']} languages={['Python']} date="2026-02-10" />
 <RecipeCard slug="browser-use-captcha-auto" title={"Solve CAPTCHAs automatically in a Browser Use agent"} description={"Build an AI agent with browser-use and Steel that solves CAPTCHAs automatically."} topics={['Agents', 'Browser Use', 'Captchas']} languages={['Python']} date="2025-02-20" />
 </RecipeGrid>
+
+## Related guides
+
+- [Solving CAPTCHAs](/overview/stealth/captcha-solving): How Steel detects and solves CAPTCHA challenges.
+- [Proxies](/overview/stealth/proxies): Route traffic through proxies to reduce CAPTCHA challenges.

--- a/content/docs/cookbook/topics/computer-use.mdx
+++ b/content/docs/cookbook/topics/computer-use.mdx
@@ -9,3 +9,9 @@ description: Model-native browser control where the LLM sees the screen and emit
 <RecipeCard slug="claude-computer-use" title={"Drive a browser with Claude Computer Use"} description={"Connect Claude to a Steel browser session for autonomous web interactions."} topics={['Computer use']} languages={['TypeScript', 'Python', 'Rust', 'Go']} date="2025-07-16" />
 <RecipeCard slug="openai-computer-use" title={"Drive a browser with OpenAI Computer Use"} description={"Connect OpenAI's Computer Use Assistant to a Steel browser session for autonomous web interactions."} topics={['Computer use']} languages={['TypeScript', 'Python', 'Rust', 'Go']} date="2025-03-19" />
 </RecipeGrid>
+
+## Related integrations
+
+- [Steel + Claude Computer Use](/integrations/claude-computer-use): Point Claude's computer-use loop at a Steel session.
+- [Steel + OpenAI Computer Use](/integrations/openai-computer-use): Point OpenAI's Computer Use Assistant at a Steel session.
+- [Steel + Gemini Computer Use](/integrations/gemini-computer-use): Point Gemini Computer Use at a Steel session.

--- a/content/docs/cookbook/topics/mobile.mdx
+++ b/content/docs/cookbook/topics/mobile.mdx
@@ -6,3 +6,7 @@ description: "Recipes targeting Steel's mobile browser environment."
 <RecipeGrid>
 <RecipeCard slug="claude-computer-use-mobile" title={"Drive a mobile browser with Claude Computer Use"} description={"Claude Computer Use with Steel for autonomous task execution in mobile browser environments."} topics={['Computer use', 'Mobile']} languages={['TypeScript']} date="2025-10-14" />
 </RecipeGrid>
+
+## Related integrations
+
+- [Steel + Claude Computer Use](/integrations/claude-computer-use): Drive Steel's mobile browser with Claude's computer-use model.

--- a/content/docs/cookbook/topics/playwright.mdx
+++ b/content/docs/cookbook/topics/playwright.mdx
@@ -8,3 +8,7 @@ description: Recipes that use Playwright to drive a Steel session, either as the
 <RecipeCard slug="extensions" title={"Upload and run browser extensions"} description={"Use the Steel Extensions API with Playwright to upload and run browser extensions."} topics={['Steel APIs', 'Playwright']} languages={['TypeScript', 'Python', 'Rust', 'Go']} date="2024-11-19" />
 <RecipeCard slug="files" title={"Move files between your machine and a cloud browser"} description={"Use the Steel Files API with Playwright to automate file uploads and downloads in the cloud."} topics={['Steel APIs', 'Playwright']} languages={['TypeScript', 'Python', 'Rust', 'Go']} date="2024-11-19" />
 </RecipeGrid>
+
+## Related integrations
+
+- [Steel + Playwright](/integrations/playwright): Set up Steel with Playwright and connect over CDP.

--- a/content/docs/cookbook/topics/subagents.mdx
+++ b/content/docs/cookbook/topics/subagents.mdx
@@ -6,3 +6,7 @@ description: Multi-agent recipes where a lead orchestrator dispatches parallel s
 <RecipeGrid>
 <RecipeCard slug="deep-research" title={"Deep research with Claude Agent SDK subagents"} description={"Lead orchestrator dispatches parallel researcher subagents, each driving its own Steel browser, and synthesizes findings into a cited Markdown report."} topics={['Agents', 'Subagents']} languages={['TypeScript', 'Python']} date="2026-05-01" />
 </RecipeGrid>
+
+## Related integrations
+
+- [Steel + Claude Agent SDK](/integrations/claude-agent-sdk): Build the orchestrator and subagents on Anthropic's agent loop.

--- a/content/docs/cookbook/topics/typed-output.mdx
+++ b/content/docs/cookbook/topics/typed-output.mdx
@@ -12,3 +12,9 @@ description: Agents that return structured, schema-validated results instead of 
 <RecipeCard slug="vercel-ai-sdk" title={"Build a typed browser agent with the Vercel AI SDK"} description={"Use Steel with the Vercel AI SDK v6 ToolLoopAgent for typed, tool-using browser agents."} topics={['Agents', 'Typed output']} languages={['TypeScript']} date="2026-04-23" />
 <RecipeCard slug="vercel-ai-sdk-nextjs" title={"Stream a browser agent into a Next.js chat app"} description={"A Next.js App Router chat app where a Vercel AI SDK agent drives a Steel cloud browser with embedded Live View."} topics={['Agents', 'Typed output', 'Next.js']} languages={['TypeScript']} date="2026-04-23" />
 </RecipeGrid>
+
+## Related integrations
+
+- [Steel + Pydantic AI](/integrations/pydantic-ai): Return typed, schema-validated agent results with Pydantic AI.
+- [Steel + LangGraph](/integrations/langgraph): Return typed agent results with an explicit LangGraph state machine.
+- [Steel + Mastra](/integrations/mastra): Return typed agent results with Mastra.

--- a/content/docs/cookbook/trigger-dev-browser-job.mdx
+++ b/content/docs/cookbook/trigger-dev-browser-job.mdx
@@ -9,7 +9,7 @@ description: Queue a Trigger.dev task that creates a Steel session, drives Playw
 
 <RecipeQuickstart slug="trigger-dev-browser-job" />
 
-This recipe runs browser automation as a queued background job. The request
+This recipe runs browser automation as a [queued background job](/cookbook/topics/triggerdev). The request
 path only enqueues `steel-browser-job`; the task creates a Steel session,
 connects Playwright over CDP, extracts a page summary, saves artifacts, and
 releases the session in `finally`.

--- a/content/docs/cookbook/vercel-ai-sdk-nextjs.mdx
+++ b/content/docs/cookbook/vercel-ai-sdk-nextjs.mdx
@@ -9,7 +9,7 @@ description: A Next.js App Router chat app where a Vercel AI SDK agent drives a 
 
 <RecipeQuickstart slug="vercel-ai-sdk-nextjs" />
 
-A Next.js chat app where an AI SDK v6 agent drives a Steel cloud browser server-side and streams every tool call back into the UI. `useChat` on the client posts to `/api/chat`; that route calls `streamText` with four Steel-backed tools (`openSession`, `navigate`, `snapshot`, `extract`). Each tool call surfaces as a typed `tool-*` part on the message stream, and a Live View iframe on the right lights up the moment the agent opens a session.
+A [Next.js](/cookbook/topics/nextjs) chat app where an [AI SDK v6](/integrations/ai-sdk) agent drives a Steel cloud browser server-side and streams every tool call back into the UI. `useChat` on the client posts to `/api/chat`; that route calls `streamText` with four Steel-backed tools (`openSession`, `navigate`, `snapshot`, `extract`). Each tool call surfaces as a typed `tool-*` part on the message stream, and a Live View iframe on the right lights up the moment the agent opens a session.
 
 ```
 app/

--- a/content/docs/cookbook/vercel-ai-sdk.mdx
+++ b/content/docs/cookbook/vercel-ai-sdk.mdx
@@ -9,7 +9,7 @@ description: Use Steel with the Vercel AI SDK v6 ToolLoopAgent for typed, tool-u
 
 <RecipeQuickstart slug="vercel-ai-sdk-ts" />
 
-The [Vercel AI SDK v6](https://ai-sdk.dev/docs/agents/overview) ships `ToolLoopAgent`, a typed agent that picks a tool, calls it, observes the result, and decides the next step. Give it tools that drive a Playwright page connected to a Steel session and you get a terminal browser agent with no UI scaffolding in the way.
+The [Vercel AI SDK v6](https://ai-sdk.dev/docs/agents/overview) ships `ToolLoopAgent`, a [typed agent](/cookbook/topics/typed-output) that picks a tool, calls it, observes the result, and decides the next step. Give it tools that drive a Playwright page connected to a Steel session and you get a terminal browser agent with no UI scaffolding in the way. Steel's [AI SDK integration](/integrations/ai-sdk) covers the same pairing on its own.
 
 ```typescript
 const researchAgent = new ToolLoopAgent({

--- a/content/docs/cookbook/you-com-search.mdx
+++ b/content/docs/cookbook/you-com-search.mdx
@@ -9,7 +9,7 @@ description: Pair the You.com Search and Contents APIs with a Steel cloud browse
 
 <RecipeQuickstart slug="you-com-search" />
 
-A search-then-act agent: [You.com](https://you.com/) handles discovery and static extraction, Steel handles real browser actions. The agent gets five tools across two cost tiers and is told to prefer the cheap tier. The Steel session is opened lazily on the first `navigate` call, so a question that resolves on search alone never spins up a browser.
+A [search-then-act agent](/cookbook/topics/search): [You.com](https://you.com/) handles discovery and static extraction, Steel handles real browser actions. The agent gets five tools across two cost tiers and is told to prefer the cheap tier. The Steel session is opened lazily on the first `navigate` call, so a question that resolves on search alone never spins up a browser.
 
 ```python
 tools = [youcom_search, youcom_contents, navigate, snapshot, click_text]

--- a/content/docs/integrations/agentkit.mdx
+++ b/content/docs/integrations/agentkit.mdx
@@ -5,7 +5,7 @@ description: Build multi-agent networks in TypeScript with routing, shared state
 llm: true
 ---
 
-AgentKit is Inngest's TypeScript framework for building agent networks: single agents or coordinated teams that share state and route work through code or model-driven routers. The Steel integration runs each agent's browser actions on a Steel cloud session, so AgentKit handles the orchestration and Steel handles the browser.
+AgentKit is Inngest's TypeScript framework for [building agent networks](/cookbook/topics/agents): single agents or coordinated teams that share state and route work through code or model-driven routers. The Steel integration runs each agent's browser actions on a Steel cloud session, so AgentKit handles the orchestration and Steel handles the browser.
 
 You can also expose MCP servers as tools and stream tokens and tool steps to a UI as the agent runs.
 

--- a/content/docs/integrations/agno.mdx
+++ b/content/docs/integrations/agno.mdx
@@ -5,7 +5,7 @@ description: Build Python agent teams with shared memory, reasoning, and RAG.
 llm: true
 ---
 
-Agno is a Python framework for building multi-agent systems with shared memory, knowledge, and reasoning. The Steel integration wraps a Steel browser as an Agno toolkit, so Agno agents can navigate, fill forms, extract data, and combine browsing with retrieval-augmented reasoning.
+Agno is a Python framework for building [multi-agent systems](/cookbook/topics/agents) with shared memory, knowledge, and reasoning. The Steel integration wraps a Steel browser as an Agno toolkit, so Agno agents can navigate, fill forms, extract data, and combine browsing with retrieval-augmented reasoning.
 
 Agno is model-agnostic and natively multi-modal, which pairs well with Steel's reliable, sandboxed cloud browsers.
 

--- a/content/docs/integrations/ai-sdk.mdx
+++ b/content/docs/integrations/ai-sdk.mdx
@@ -5,7 +5,7 @@ description: Give the Vercel AI SDK a browser tool with Steel. Build typed TypeS
 llm: true
 ---
 
-The Vercel AI SDK is a TypeScript toolkit for building AI applications with typed tools, streaming, and a unified provider model. The Steel integration runs each tool against a Steel cloud session (open, navigate, snapshot, extract, return typed results), so you can stand up a typed browser agent in a few hundred lines.
+The Vercel AI SDK is a TypeScript toolkit for building AI applications with typed tools, streaming, and a unified provider model. The Steel integration runs each tool against a Steel cloud session (open, navigate, snapshot, extract, return typed results), so you can stand up a [typed browser agent](/cookbook/topics/agents) in a few hundred lines.
 
 Pair the agent with a Next.js chat UI and embed Steel's Live View iframe alongside the chat to watch the browser as the agent runs.
 

--- a/content/docs/integrations/browser-use.mdx
+++ b/content/docs/integrations/browser-use.mdx
@@ -5,7 +5,7 @@ description: Run Browser Use in the cloud with Steel. Point the open-source Pyth
 llm: true
 ---
 
-The Browser Use integration connects Steel's browser infrastructure with the Browser Use agent framework, enabling AI models to perform complex web interactions. Agents can navigate websites, fill forms, click buttons, extract data, and complete multi-step tasks – all while leveraging Steel's reliable cloud browsers for execution. This integration bridges the gap between AI capabilities and real-world web applications without requiring custom API development.
+The Browser Use integration connects Steel's browser infrastructure with the [Browser Use agent framework](/cookbook/topics/browser-use), enabling AI models to perform complex web interactions. Agents can navigate websites, fill forms, click buttons, extract data, and complete multi-step tasks – all while leveraging Steel's reliable cloud browsers for execution. This integration bridges the gap between AI capabilities and real-world web applications without requiring custom API development.
 
 ### Requirements
 

--- a/content/docs/integrations/claude-agent-sdk.mdx
+++ b/content/docs/integrations/claude-agent-sdk.mdx
@@ -55,6 +55,8 @@ Pass the server into `query()` via `mcpServers` and pre-approve calls with `allo
 
 Full runnable starter: [Steel + Claude Agent SDK recipe →](/cookbook/claude-agent-sdk)
 
+Steel runs the same way across [other agent frameworks](/cookbook/topics/agents).
+
 ### FAQ
 
 :::faq

--- a/content/docs/integrations/claude-code.mdx
+++ b/content/docs/integrations/claude-code.mdx
@@ -7,7 +7,7 @@ llm: true
 
 The Claude Code integration gives Claude Code a real cloud browser through the Steel CLI. From a Claude Code session, you can start and control Steel sessions, scrape rendered pages, run computer-use actions, watch live browser state through the session viewer, and turn successful runs into repeatable scripts.
 
-Claude Code already works well with shell commands; Steel adds the browser surface for sites that need JavaScript, session state, or interactive navigation.
+Claude Code already works well with shell commands; Steel adds the browser surface for sites that need JavaScript, session state, or interactive navigation. Steel works the same way with [other agents and frameworks](/cookbook/topics/agents), from CrewAI to LangGraph.
 
 ### Requirements
 

--- a/content/docs/integrations/claude-computer-use.mdx
+++ b/content/docs/integrations/claude-computer-use.mdx
@@ -5,7 +5,7 @@ description: Wire Claude's computer-use tool into a Steel browser session.
 llm: true
 ---
 
-The Claude Computer Use integration runs Anthropic's vision-based agent loop on a Steel browser session. Claude takes screenshots through Steel, decides the next action (click, type, scroll), and Steel executes it, so you can automate complex web tasks without writing custom selectors.
+The Claude Computer Use integration runs Anthropic's [vision-based agent loop](/cookbook/topics/computer-use) on a Steel browser session. Claude takes screenshots through Steel, decides the next action (click, type, scroll), and Steel executes it, so you can automate complex web tasks without writing custom selectors.
 
 It pairs well with Steel's anti-bot capabilities, proxy support, and sandboxed environments.
 

--- a/content/docs/integrations/codex.mdx
+++ b/content/docs/integrations/codex.mdx
@@ -7,7 +7,7 @@ llm: true
 
 The Codex integration gives Codex a real cloud browser through the Steel CLI. From a Codex session, you can start and control Steel sessions, scrape rendered pages, run computer-use actions, and turn one-off runs into reusable scripts.
 
-Codex and Steel fit together well because both are command-line tools. Once Steel CLI is on your `PATH`, Codex can inspect command help, run the commands it needs, and verify results from the terminal.
+Codex and Steel fit together well because both are command-line tools. The same CLI setup works with [other agents and frameworks](/cookbook/topics/agents) too. Once Steel CLI is on your `PATH`, Codex can inspect command help, run the commands it needs, and verify results from the terminal.
 
 ### Requirements
 

--- a/content/docs/integrations/crewai.mdx
+++ b/content/docs/integrations/crewai.mdx
@@ -5,7 +5,7 @@ description: Give CrewAI agents a real browser with Steel. Orchestrate multi-age
 llm: true
 ---
 
-CrewAI is a Python framework for orchestrating multi-agent workflows with autonomous teams (crews) and event-driven flows. The Steel integration exposes a Steel browser as a CrewAI tool, so your crew can search, navigate, fill forms, extract data, and validate results across collaborating agents.
+CrewAI is a Python framework for orchestrating [multi-agent workflows](/cookbook/topics/agents) with autonomous teams (crews) and event-driven flows. The Steel integration exposes a Steel browser as a CrewAI tool, so your crew can search, navigate, fill forms, extract data, and validate results across collaborating agents.
 
 You can mix autonomy with precise control, share memory across steps, return structured outputs, and add human-in-the-loop checkpoints for sensitive actions.
 

--- a/content/docs/integrations/gemini-computer-use.mdx
+++ b/content/docs/integrations/gemini-computer-use.mdx
@@ -5,7 +5,7 @@ description: Wire Gemini 3's computer-use tool into a Steel browser session.
 llm: true
 ---
 
-The Gemini Computer Use integration runs Gemini 3's vision-based agent loop on a Steel browser session. Gemini takes screenshots through Steel, decides the next action (click, type, scroll), and Steel executes it, so you can automate complex web tasks without writing custom selectors.
+The Gemini Computer Use integration runs Gemini 3's [vision-based agent loop](/cookbook/topics/computer-use) on a Steel browser session. Gemini takes screenshots through Steel, decides the next action (click, type, scroll), and Steel executes it, so you can automate complex web tasks without writing custom selectors.
 
 It pairs well with Steel's anti-bot capabilities, proxy support, and sandboxed environments.
 

--- a/content/docs/integrations/hermes-agent.mdx
+++ b/content/docs/integrations/hermes-agent.mdx
@@ -17,7 +17,7 @@ The pending Hermes integration adds Steel as a cloud browser provider inside Her
 *   Support for Steel-specific options such as proxying and CAPTCHA solving
 *   Viewer URL support so you can monitor browser sessions while the agent runs
 
-If this ships as proposed, Hermes users will be able to route browser tasks through Steel by setting `STEEL_API_KEY` and selecting Steel in Hermes configuration.
+If this ships as proposed, Hermes users will be able to route browser tasks through Steel by setting `STEEL_API_KEY` and selecting Steel in Hermes configuration. Meanwhile, [other agent frameworks](/cookbook/topics/agents) already route browser tasks through Steel today.
 
 ### Requirements
 

--- a/content/docs/integrations/langgraph.mdx
+++ b/content/docs/integrations/langgraph.mdx
@@ -5,7 +5,7 @@ description: Build a LangGraph browser agent on Steel cloud browsers. Model web 
 llm: true
 ---
 
-[LangGraph](https://langchain-ai.github.io/langgraph/) builds agents as state machines: nodes do work, edges route control, and the agent loop is something you compose explicitly rather than something the framework hides for you. LangChain ships the model wrappers and `@tool` decorator; LangGraph ships the runtime, plus prebuilt `ToolNode` and `tools_condition` helpers that turn three nodes and four edges into a tool-calling agent. The Steel integration runs each `@tool` against a Steel cloud session, so the agent loop drives a real browser.
+[LangGraph](https://langchain-ai.github.io/langgraph/) builds agents as state machines: nodes do work, edges route control, and the agent loop is something you compose explicitly rather than something the framework hides for you. LangChain ships the model wrappers and `@tool` decorator; LangGraph ships the runtime, plus prebuilt `ToolNode` and `tools_condition` helpers that turn three nodes and four edges into a [tool-calling agent](/cookbook/topics/agents). The Steel integration runs each `@tool` against a Steel cloud session, so the agent loop drives a real browser.
 
 ### Requirements
 

--- a/content/docs/integrations/magnitude.mdx
+++ b/content/docs/integrations/magnitude.mdx
@@ -5,7 +5,7 @@ description: Turn natural-language prompts into typed browser actions and struct
 llm: true
 ---
 
-Magnitude is a TypeScript browser-agent framework that turns natural-language prompts into typed actions. The Steel integration runs Magnitude's planning loop on a Steel cloud browser, so you can drive a real session from prompts and end with structured outputs validated against a schema.
+Magnitude is a TypeScript [browser-agent framework](/cookbook/topics/agents) that turns natural-language prompts into typed actions. The Steel integration runs Magnitude's planning loop on a Steel cloud browser, so you can drive a real session from prompts and end with structured outputs validated against a schema.
 
 Good fit for research-style flows that mix navigation and extraction.
 

--- a/content/docs/integrations/mastra.mdx
+++ b/content/docs/integrations/mastra.mdx
@@ -60,6 +60,8 @@ Tools are passed as a record (not an array): the keys are what the model sees as
 
 Full runnable starter: [Steel + Mastra recipe →](/cookbook/mastra)
 
+Steel runs the same way across [other agent frameworks](/cookbook/topics/agents).
+
 ### FAQ
 
 :::faq

--- a/content/docs/integrations/notte.mdx
+++ b/content/docs/integrations/notte.mdx
@@ -5,7 +5,7 @@ description: Reliable Python web-agent framework focused on stable navigation an
 llm: true
 ---
 
-Notte is a Python framework for building reliable web agents with stable navigation and structured outputs. The Steel integration connects a Notte session to a Steel browser, so Notte handles the agent loop and Steel handles the cloud browser plumbing.
+Notte is a Python framework for building [reliable web agents](/cookbook/topics/agents) with stable navigation and structured outputs. The Steel integration connects a Notte session to a Steel browser, so Notte handles the agent loop and Steel handles the cloud browser plumbing.
 
 Use it for tasks where reliable navigation and typed outputs matter more than autonomy.
 

--- a/content/docs/integrations/openai-agents-sdk.mdx
+++ b/content/docs/integrations/openai-agents-sdk.mdx
@@ -5,7 +5,7 @@ description: Use the OpenAI Agents SDK with a Steel cloud browser. Build typed b
 llm: true
 ---
 
-The OpenAI Agents SDK is OpenAI's official toolkit for building agents with typed tools, handoffs, guardrails, and tracing. The Steel integration runs each tool against a Steel cloud session, so you can stand up a typed browser agent that opens a session, navigates, extracts data, and returns a validated final report.
+The OpenAI Agents SDK is OpenAI's official toolkit for building agents with typed tools, handoffs, guardrails, and tracing. The Steel integration runs each tool against a Steel cloud session, so you can stand up a [typed browser agent](/cookbook/topics/agents) that opens a session, navigates, extracts data, and returns a validated final report.
 
 Available in TypeScript and Python.
 

--- a/content/docs/integrations/openai-computer-use.mdx
+++ b/content/docs/integrations/openai-computer-use.mdx
@@ -5,7 +5,7 @@ description: Wire OpenAI's computer-use tool into a Steel browser session.
 llm: true
 ---
 
-The OpenAI Computer Use integration runs OpenAI's vision-based agent loop on a Steel browser session. The model takes screenshots through Steel, decides the next action (click, type, scroll), and Steel executes it, so you can automate complex web tasks without writing custom selectors.
+The OpenAI Computer Use integration runs OpenAI's [vision-based agent loop](/cookbook/topics/computer-use) on a Steel browser session. The model takes screenshots through Steel, decides the next action (click, type, scroll), and Steel executes it, so you can automate complex web tasks without writing custom selectors.
 
 It pairs well with Steel's anti-bot capabilities, proxy support, and sandboxed environments.
 

--- a/content/docs/integrations/openclaw.mdx
+++ b/content/docs/integrations/openclaw.mdx
@@ -7,7 +7,7 @@ llm: true
 
 The OpenClaw integration gives OpenClaw a real cloud browser through the Steel CLI. Once Steel CLI is on your `PATH`, OpenClaw can run multi-step web tasks, scrape rendered pages, watch live browser state, and work through forms and dynamic pages without writing custom integration code.
 
-Good fit for application forms, operational workflows, and browser-driven research.
+Good fit for application forms, operational workflows, and browser-driven research. The same setup works with [other agent frameworks](/cookbook/topics/agents) like CrewAI and LangGraph.
 
 ### Requirements
 

--- a/content/docs/integrations/pi-agent.mdx
+++ b/content/docs/integrations/pi-agent.mdx
@@ -9,7 +9,7 @@ llm: true
 This integration is part of Steel's experiments effort. Defaults can change without notice, and stability is not guaranteed.
 :::
 
-[Pi](https://pi.dev/) is a minimal, extension-first coding agent that ships with no built-in browser; capabilities arrive through `pi install`. The Pi integration installs as a native Pi extension that gives Pi a Steel cloud browser, so Pi can navigate, scrape rendered pages, extract structured data, capture screenshots and PDFs, and fill forms across prompts.
+[Pi](https://pi.dev/) is a minimal, extension-first coding agent that ships with no built-in browser; capabilities arrive through `pi install`. The Pi integration installs as a native Pi extension that gives Pi a Steel cloud browser, so Pi can navigate, scrape rendered pages, extract structured data, capture screenshots and PDFs, and fill forms across prompts. Steel plugs into [other agents and frameworks](/cookbook/topics/agents) the same way, with a runnable recipe for each.
 
 ### Requirements
 

--- a/content/docs/integrations/playwright.mdx
+++ b/content/docs/integrations/playwright.mdx
@@ -5,7 +5,7 @@ description: Run Playwright in the cloud with Steel. Connect over CDP in TypeScr
 llm: true
 ---
 
-Playwright is Microsoft's cross-browser automation library. The Steel integration attaches Playwright to a Steel cloud session over the Chrome DevTools Protocol, so the rest of your script — `page.goto`, locators, `expect`, tracing — drives a remote browser with stealth, proxies, and a live viewer instead of a local Chromium.
+Playwright is Microsoft's [cross-browser automation library](/cookbook/topics/playwright). The Steel integration attaches Playwright to a Steel cloud session over the Chrome DevTools Protocol, so the rest of your script — `page.goto`, locators, `expect`, tracing — drives a remote browser with stealth, proxies, and a live viewer instead of a local Chromium.
 
 No `playwright install`, no headful display, no Chrome on your machine.
 

--- a/content/docs/integrations/puppeteer.mdx
+++ b/content/docs/integrations/puppeteer.mdx
@@ -5,7 +5,7 @@ description: Run Puppeteer in the cloud with Steel. Connect over CDP in TypeScri
 llm: true
 ---
 
-Puppeteer is Chrome's reference Node.js automation library. The Steel integration attaches Puppeteer to a Steel cloud session through `puppeteer.connect()`, so `page.goto`, `page.evaluate`, `page.waitForSelector`, and the rest of the surface drive a remote browser. Stealth, proxies, and the live session viewer come from Steel without extra wiring.
+Puppeteer is Chrome's reference [Node.js automation library](/cookbook/topics/browser-automation). The Steel integration attaches Puppeteer to a Steel cloud session through `puppeteer.connect()`, so `page.goto`, `page.evaluate`, `page.waitForSelector`, and the rest of the surface drive a remote browser. Stealth, proxies, and the live session viewer come from Steel without extra wiring.
 
 The package is `puppeteer-core` — there's no Chromium to download because the browser lives on Steel.
 

--- a/content/docs/integrations/pydantic-ai.mdx
+++ b/content/docs/integrations/pydantic-ai.mdx
@@ -5,7 +5,7 @@ description: "Build a Pydantic AI browser agent on Steel cloud browsers: provide
 llm: true
 ---
 
-[Pydantic AI](https://ai.pydantic.dev/) is the Pydantic team's agent framework. It's provider-agnostic and reuses the Pydantic models you'd already validate API I/O with for tool arguments and final outputs, so adding an agent to a typed Python codebase doesn't introduce a parallel schema layer. The Steel integration passes a Playwright `Page` through `RunContext.deps`, so every tool in an agent run sees the same cloud browser without module globals.
+[Pydantic AI](https://ai.pydantic.dev/) is the Pydantic team's [agent framework](/cookbook/topics/agents). It's provider-agnostic and reuses the Pydantic models you'd already validate API I/O with for tool arguments and final outputs, so adding an agent to a typed Python codebase doesn't introduce a parallel schema layer. The Steel integration passes a Playwright `Page` through `RunContext.deps`, so every tool in an agent run sees the same cloud browser without module globals.
 
 ### Requirements
 

--- a/content/docs/integrations/replit.mdx
+++ b/content/docs/integrations/replit.mdx
@@ -5,7 +5,7 @@ description: Remix Steel browser-automation starter templates and run them in Re
 llm: true
 ---
 
-Run Steel browser automation scripts in Replit's cloud, no local setup. Templates ship for Python and Node.js with Playwright, Puppeteer, and Selenium.
+Run [Steel browser automation scripts](/cookbook/topics/browser-automation) in Replit's cloud, no local setup. Templates ship for Python and Node.js with Playwright, Puppeteer, and Selenium.
 
 A good fit for prototyping, scheduled jobs, and sharing runnable examples.
 

--- a/content/docs/integrations/selenium.mdx
+++ b/content/docs/integrations/selenium.mdx
@@ -52,6 +52,8 @@ Each command is an HTTP round-trip, so prefer `WebDriverWait` with `expected_con
 
 Full runnable starter: [Steel + Selenium recipe →](/cookbook/selenium)
 
+Steel drives [Playwright and Puppeteer](/cookbook/topics/browser-automation) the same way.
+
 ### FAQ
 
 :::faq

--- a/content/docs/integrations/stackblitz-bolt.new.mdx
+++ b/content/docs/integrations/stackblitz-bolt.new.mdx
@@ -5,7 +5,7 @@ description: Run Steel TypeScript starter templates in your browser, no install.
 llm: true
 ---
 
-Run Steel browser automation scripts in StackBlitz directly in your browser, with no local setup or installation. Well-suited for quick prototyping, sharing running examples, and collaborative development.
+Run [Steel browser automation scripts](/cookbook/topics/browser-automation) in StackBlitz directly in your browser, with no local setup or installation. Well-suited for quick prototyping, sharing running examples, and collaborative development.
 
 With [Bolt.new](http://bolt.new/), StackBlitz's AI-powered web development agent, you can write and modify Steel scripts in natural language alongside your code.
 

--- a/content/docs/integrations/stagehand.mdx
+++ b/content/docs/integrations/stagehand.mdx
@@ -5,7 +5,7 @@ description: Run Stagehand on Steel cloud browsers. Write automations in natural
 llm: true
 ---
 
-Stagehand is an open-source library for writing browser automations in natural language using `act`, `extract`, and `observe` calls. The Steel integration drives Stagehand against a Steel cloud session, so you can replace fragile selectors with instructions like "click the login button" or "extract the top 3 stories". Same API in TypeScript or Python.
+Stagehand is an open-source library for writing [browser automations](/cookbook/topics/browser-automation) in natural language using `act`, `extract`, and `observe` calls. The Steel integration drives Stagehand against a Steel cloud session, so you can replace fragile selectors with instructions like "click the login button" or "extract the top 3 stories". Same API in TypeScript or Python.
 
 Good fit for research, scraping, and form workflows.
 

--- a/content/docs/integrations/x402.mdx
+++ b/content/docs/integrations/x402.mdx
@@ -5,7 +5,7 @@ description: Pay-per-use Steel API calls with USDC on Base and Solana. No API ke
 llm: true
 ---
 
-The x402 integration lets you call Steel's web actions — scrape, screenshot, and PDF — and pay per request with USDC on Base or Solana. It's built on the [x402 protocol](https://www.x402.org/), so there are no API keys or accounts: you pay for each call with your wallet.
+The x402 integration lets you call [Steel's web actions](/cookbook/topics/steel-apis) — scrape, screenshot, and PDF — and pay per request with USDC on Base or Solana. It's built on the [x402 protocol](https://www.x402.org/), so there are no API keys or accounts: you pay for each call with your wallet.
 
 **Endpoint:** `https://x402.steel.dev`
 


### PR DESCRIPTION
## What

Technical fix #4 from `SEO-OPPORTUNITIES.md` (Days 0–14): internal-linking depth. Integration pages, cookbook recipes, and topic hubs were under-connected — all 27 integration pages linked no topic hub, 8 orphan integration pages linked nothing, and topic hubs were pure `<RecipeGrid>` components with zero outbound integration links.

**107 internal links** woven into existing prose across **82 files**:

- **Integrations** — every page now links a relevant topic hub (agents for frameworks, computer-use for vision-loop pages, browser-automation for playwright/puppeteer/selenium). The 8 orphans (x402, replit, codex, claude-code, openclaw, pi-agent, hermes-agent, stackblitz) get internal links for the first time.
- **Recipes** — backlinks to their matching integration page where one exists, plus a topic-hub link. Mapped non-identical names (openai-agents → openai-agents-sdk, vercel-ai-sdk → ai-sdk).
- **Topic hubs** — a new `## Related integrations` section after the recipe grid on 8 hubs (playwright, browser-use, computer-use, captchas, browser-automation, subagents, mobile, typed-output).

## How it was built

Proposals drafted by **4 parallel agents** (integrations / recipes A–G / recipes H–Z / topic hubs), each returning exact insertions with anchor snippets. I merged and validated all 107 against the real files before applying:
- every link target exists on disk
- every anchor text matches exactly once (or chains off a prior insertion)
- no em dashes, no duplicate links

8 `insert-after` proposals glued onto preceding text on first apply (no leading whitespace); fixed each — 3 became their own paragraph after the recipe-link line, 5 got a sentence space.

## Verified

- `bun run check` (Biome): clean
- `bun run validate-links`: 0 errors
- Dev-server smoke test: all 7 edited page types + all link targets return 200
- DOM check: new links render (computer-use hub shows all 3 integration links; selenium shows recipe + browser-automation; langgraph recipe shows agents hub + integration backlink)