### PR TITLE
feat(llms): serve markdown at .md-suffixed docs URLs

### DIFF
--- a/lib/markdown-negotiation.ts
+++ b/lib/markdown-negotiation.ts
@@ -30,6 +30,65 @@ export const MARKDOWN_USER_AGENT_SUBSTRINGS = [
 
 const MARKDOWN_VARY_HEADERS = ['Accept', 'User-Agent'];
 
+const EXCLUDED_EXACT_PATHS = new Set([
+  '/.well-known/llms.txt',
+  '/favicon.ico',
+  '/llms-full.txt',
+  '/llms.txt',
+  '/overview/llms-full.txt',
+  '/robots.txt',
+  '/sitemap.xml',
+]);
+
+const EXCLUDED_PATH_PREFIXES = ['/_next', '/api', '/llms.mdx', '/og'];
+const EXCLUDED_ASSET_EXTENSIONS = new Set([
+  '.avif',
+  '.css',
+  '.gif',
+  '.ico',
+  '.jpeg',
+  '.jpg',
+  '.js',
+  '.json',
+  '.map',
+  '.otf',
+  '.pdf',
+  '.png',
+  '.svg',
+  '.ttf',
+  '.txt',
+  '.webp',
+  '.woff',
+  '.woff2',
+  '.xml',
+  '.zip',
+]);
+
+function matchesPathPrefix(pathname: string, prefix: string): boolean {
+  return pathname === prefix || pathname.startsWith(`${prefix}/`);
+}
+
+function hasExcludedAssetExtension(pathname: string): boolean {
+  const extension = pathname.match(/\.[^./]+$/)?.[0]?.toLowerCase();
+  return extension ? EXCLUDED_ASSET_EXTENSIONS.has(extension) : false;
+}
+
+export function isNegotiableDocsPath(pathname: string): boolean {
+  if (EXCLUDED_EXACT_PATHS.has(pathname)) return false;
+  if (EXCLUDED_PATH_PREFIXES.some((prefix) => matchesPathPrefix(pathname, prefix))) return false;
+
+  return !hasExcludedAssetExtension(pathname);
+}
+
+export function resolveMarkdownPath(pathname: string): string | null {
+  if (!pathname.endsWith('.md')) return null;
+
+  const stripped = pathname.slice(0, -'.md'.length);
+  if (!stripped || stripped === '/') return null;
+
+  return isNegotiableDocsPath(stripped) ? stripped : null;
+}
+
 function acceptsMarkdownType(mediaType: string): boolean {
   return MARKDOWN_ACCEPT_TYPES.has(mediaType) || mediaType.endsWith('+markdown');
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,60 +1,15 @@
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
-import { appendMarkdownVaryHeader, shouldServeMarkdown } from '@/lib/markdown-negotiation';
-
-const EXCLUDED_EXACT_PATHS = new Set([
-  '/.well-known/llms.txt',
-  '/favicon.ico',
-  '/llms-full.txt',
-  '/llms.txt',
-  '/overview/llms-full.txt',
-  '/robots.txt',
-  '/sitemap.xml',
-]);
-
-const EXCLUDED_PATH_PREFIXES = ['/_next', '/api', '/llms.mdx', '/og'];
-const EXCLUDED_ASSET_EXTENSIONS = new Set([
-  '.avif',
-  '.css',
-  '.gif',
-  '.ico',
-  '.jpeg',
-  '.jpg',
-  '.js',
-  '.json',
-  '.map',
-  '.otf',
-  '.pdf',
-  '.png',
-  '.svg',
-  '.ttf',
-  '.txt',
-  '.webp',
-  '.woff',
-  '.woff2',
-  '.xml',
-  '.zip',
-]);
+import {
+  appendMarkdownVaryHeader,
+  isNegotiableDocsPath,
+  resolveMarkdownPath,
+  shouldServeMarkdown,
+} from '@/lib/markdown-negotiation';
 
 function isProgrammaticClient(request: NextRequest): boolean {
   // Browsers always send Sec-Fetch-Dest; curl/WebFetch/python-requests do not
   return !request.headers.has('sec-fetch-dest');
-}
-
-function matchesPathPrefix(pathname: string, prefix: string): boolean {
-  return pathname === prefix || pathname.startsWith(`${prefix}/`);
-}
-
-function hasExcludedAssetExtension(pathname: string): boolean {
-  const extension = pathname.match(/\.[^./]+$/)?.[0]?.toLowerCase();
-  return extension ? EXCLUDED_ASSET_EXTENSIONS.has(extension) : false;
-}
-
-function isNegotiableDocsPath(pathname: string): boolean {
-  if (EXCLUDED_EXACT_PATHS.has(pathname)) return false;
-  if (EXCLUDED_PATH_PREFIXES.some((prefix) => matchesPathPrefix(pathname, prefix))) return false;
-
-  return !hasExcludedAssetExtension(pathname);
 }
 
 function isNegotiableMethod(method: string): boolean {
@@ -71,6 +26,14 @@ export default function middleware(request: NextRequest) {
 
   if (!isNegotiableMethod(request.method)) {
     return NextResponse.next();
+  }
+
+  // An explicit .md request gets markdown unconditionally, no header sniffing
+  const markdownPath = resolveMarkdownPath(pathname);
+  if (markdownPath) {
+    const rewriteUrl = request.nextUrl.clone();
+    rewriteUrl.pathname = `/llms.mdx${markdownPath}`;
+    return NextResponse.rewrite(rewriteUrl);
   }
 
   const wantsMarkdown = shouldServeMarkdown(request.headers);

--- a/tests/e2e/md-suffix.test.ts
+++ b/tests/e2e/md-suffix.test.ts
@@ -22,8 +22,11 @@ async function waitForServer(): Promise<void> {
   const deadline = Date.now() + 90000;
   while (Date.now() < deadline) {
     try {
-      const response = await fetch(`${BASE_URL}/llms.txt`, { headers: BROWSER_HEADERS });
-      if (response.ok) return;
+      // Any HTTP response means the server is up; fetch throws until the
+      // port accepts connections. Don't probe generated files like
+      // /llms.txt, which don't exist in CI when tests run.
+      await fetch(BASE_URL, { headers: BROWSER_HEADERS });
+      return;
     } catch {
       // Server not accepting connections yet
     }

--- a/tests/e2e/md-suffix.test.ts
+++ b/tests/e2e/md-suffix.test.ts
@@ -45,8 +45,11 @@ describe('.md suffix end-to-end', () => {
     await waitForServer();
   });
 
-  afterAll(() => {
+  afterAll(async () => {
+    // Wait for the process to fully exit so the dev server's CPU and port
+    // are released before later test files (Chromium renders) start.
     server?.kill();
+    await server?.exited;
   });
 
   test('serves markdown at a .md-suffixed docs URL', async () => {

--- a/tests/e2e/md-suffix.test.ts
+++ b/tests/e2e/md-suffix.test.ts
@@ -1,0 +1,72 @@
+// ABOUTME: End-to-end tests that boot the Next.js dev server and verify
+// ABOUTME: .md-suffixed docs URLs serve markdown while canonical URLs stay HTML.
+import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from 'bun:test';
+import { fileURLToPath } from 'node:url';
+
+// The dev server compiles the middleware and markdown route on first request.
+setDefaultTimeout(120000);
+
+const PROJECT_ROOT = fileURLToPath(new URL('../..', import.meta.url));
+const PORT = 3300 + Math.floor(Math.random() * 300);
+const BASE_URL = `http://localhost:${PORT}`;
+
+const BROWSER_HEADERS = {
+  accept: 'text/html,application/xhtml+xml',
+  'sec-fetch-dest': 'document',
+  'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Safari/605.1.15',
+};
+
+let server: ReturnType<typeof Bun.spawn>;
+
+async function waitForServer(): Promise<void> {
+  const deadline = Date.now() + 90000;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`${BASE_URL}/llms.txt`, { headers: BROWSER_HEADERS });
+      if (response.ok) return;
+    } catch {
+      // Server not accepting connections yet
+    }
+    await Bun.sleep(1000);
+  }
+  throw new Error(`Dev server did not become ready on port ${PORT}`);
+}
+
+describe('.md suffix end-to-end', () => {
+  beforeAll(async () => {
+    server = Bun.spawn(['bunx', 'next', 'dev', '--turbopack', '-p', String(PORT)], {
+      cwd: PROJECT_ROOT,
+      stdout: 'ignore',
+      stderr: 'ignore',
+    });
+    await waitForServer();
+  });
+
+  afterAll(() => {
+    server?.kill();
+  });
+
+  test('serves markdown at a .md-suffixed docs URL', async () => {
+    const response = await fetch(`${BASE_URL}/overview/sessions-api/quickstart.md`, {
+      headers: BROWSER_HEADERS,
+    });
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toStartWith('text/markdown');
+    expect(await response.text()).toStartWith('# Quickstart');
+  });
+
+  test('returns 404 for a .md URL with no matching page', async () => {
+    const response = await fetch(`${BASE_URL}/nonexistent-page.md`, {
+      headers: BROWSER_HEADERS,
+    });
+    expect(response.status).toBe(404);
+  });
+
+  test('still serves HTML at the canonical URL for browsers', async () => {
+    const response = await fetch(`${BASE_URL}/overview/sessions-api/quickstart`, {
+      headers: BROWSER_HEADERS,
+    });
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toStartWith('text/html');
+  });
+});

--- a/tests/markdown-negotiation.test.ts
+++ b/tests/markdown-negotiation.test.ts
@@ -1,0 +1,39 @@
+// ABOUTME: Tests for resolveMarkdownPath, which maps .md-suffixed docs URLs
+// ABOUTME: to their canonical path so middleware can serve the markdown version.
+import { describe, expect, test } from 'bun:test';
+import { resolveMarkdownPath } from '../lib/markdown-negotiation';
+
+describe('resolveMarkdownPath', () => {
+  test('strips .md from a docs page path', () => {
+    expect(resolveMarkdownPath('/overview/sessions-api/quickstart.md')).toBe(
+      '/overview/sessions-api/quickstart',
+    );
+  });
+
+  test('strips .md from a top-level section path', () => {
+    expect(resolveMarkdownPath('/cookbook.md')).toBe('/cookbook');
+  });
+
+  test('returns null for paths without the .md suffix', () => {
+    expect(resolveMarkdownPath('/overview/sessions-api/quickstart')).toBeNull();
+    expect(resolveMarkdownPath('/')).toBeNull();
+  });
+
+  test('returns null for a bare /.md', () => {
+    expect(resolveMarkdownPath('/.md')).toBeNull();
+  });
+
+  test('returns null when the stripped path is an excluded exact path', () => {
+    expect(resolveMarkdownPath('/llms-full.txt.md')).toBeNull();
+    expect(resolveMarkdownPath('/llms.txt.md')).toBeNull();
+  });
+
+  test('returns null when the stripped path is under an excluded prefix', () => {
+    expect(resolveMarkdownPath('/llms.mdx/overview.md')).toBeNull();
+    expect(resolveMarkdownPath('/api/search.md')).toBeNull();
+  });
+
+  test('returns null when the stripped path is a static asset', () => {
+    expect(resolveMarkdownPath('/images/logo.png.md')).toBeNull();
+  });
+});

--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -1,0 +1,44 @@
+// ABOUTME: Integration tests for the docs middleware, verifying .md-suffixed
+// ABOUTME: URLs rewrite to the /llms.mdx markdown route and others pass through.
+import { describe, expect, test } from 'bun:test';
+import { NextRequest } from 'next/server';
+import middleware from '../middleware';
+
+function browserRequest(url: string): NextRequest {
+  return new NextRequest(url, {
+    headers: {
+      accept: 'text/html,application/xhtml+xml',
+      'sec-fetch-dest': 'document',
+      'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Safari/605.1.15',
+    },
+  });
+}
+
+describe('middleware .md suffix handling', () => {
+  test('rewrites a .md-suffixed docs URL to the llms.mdx route', () => {
+    const response = middleware(browserRequest('http://localhost/overview/steel-cli.md'));
+    const rewrite = response.headers.get('x-middleware-rewrite');
+    expect(rewrite).not.toBeNull();
+    expect(new URL(rewrite as string).pathname).toBe('/llms.mdx/overview/steel-cli');
+  });
+
+  test('rewrites .md URLs even for markdown user agents', () => {
+    const request = new NextRequest('http://localhost/cookbook/playwright.md', {
+      headers: { 'user-agent': 'claude-code/1.0' },
+    });
+    const response = middleware(request);
+    const rewrite = response.headers.get('x-middleware-rewrite');
+    expect(rewrite).not.toBeNull();
+    expect(new URL(rewrite as string).pathname).toBe('/llms.mdx/cookbook/playwright');
+  });
+
+  test('leaves canonical docs URLs from browsers untouched', () => {
+    const response = middleware(browserRequest('http://localhost/overview/steel-cli'));
+    expect(response.headers.get('x-middleware-rewrite')).toBeNull();
+  });
+
+  test('does not rewrite excluded .md paths', () => {
+    const response = middleware(browserRequest('http://localhost/llms-full.txt.md'));
+    expect(response.headers.get('x-middleware-rewrite')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Any docs URL with `.md` appended now serves the page's markdown version, e.g. `https://docs.steel.dev/overview/sessions-api/quickstart.md`. Coding agents guess these URLs (the convention is part of the llms.txt spec and supported by Stripe, Anthropic, and Mintlify/Fern sites); previously they all 404'd since per-page markdown was only reachable at the internal `/llms.mdx/<slug>` route.
- New `resolveMarkdownPath()` helper in `lib/markdown-negotiation.ts` strips the suffix and validates the path; the middleware rewrites matching requests to `/llms.mdx/<path>` unconditionally (no Accept/user-agent sniffing needed for an explicit `.md` request).
- The path-exclusion logic (`isNegotiableDocsPath` and its constants) moved from `middleware.ts` into `lib/markdown-negotiation.ts` unchanged, so the helper reuses it instead of duplicating the rules and both are unit-testable.
- Excluded paths stay excluded: `/llms-full.txt.md`, `/llms.mdx/*.md`, asset paths like `/images/foo.png.md` all pass through untouched. Nonexistent pages 404 via the existing `notFound()` in the llms.mdx route.

## Testing
- Unit: `tests/markdown-negotiation.test.ts` covers `resolveMarkdownPath` (valid paths, no suffix, bare `/.md`, excluded exacts/prefixes/assets).
- Integration: `tests/middleware.test.ts` asserts the `x-middleware-rewrite` target for `.md` requests and no rewrite for browser requests to canonical or excluded URLs.
- E2E: `tests/e2e/md-suffix.test.ts` boots the dev server and verifies 200 `text/markdown` for `.md` URLs, 404 for unknown pages, and HTML for canonical browser requests.
- `bun test tests/` (153 pass), `bun run check` clean, `bun run build` succeeds.