### PR TITLE
feat(llms): drop cookbook author pages and advertise .md URLs

### DIFF
--- a/content/docs/cookbook/authors/aspectrr.mdx
+++ b/content/docs/cookbook/authors/aspectrr.mdx
@@ -1,6 +1,7 @@
 ---
 title: Collin Pfeifer
 description: 3 recipes contributed to the Steel Cookbook by Collin Pfeifer.
+llm: false
 ---
 
 <AuthorProfile handle="aspectrr" name={"Collin Pfeifer"} avatar="https://github.com/aspectrr.png?size=40" />

--- a/content/docs/cookbook/authors/bsparker.mdx
+++ b/content/docs/cookbook/authors/bsparker.mdx
@@ -1,6 +1,7 @@
 ---
 title: Brian Sparker
 description: 1 recipe contributed to the Steel Cookbook by Brian Sparker.
+llm: false
 ---
 
 <AuthorProfile handle="bsparker" name={"Brian Sparker"} avatar="https://github.com/bsparker.png?size=40" />

--- a/content/docs/cookbook/authors/danew.mdx
+++ b/content/docs/cookbook/authors/danew.mdx
@@ -1,6 +1,7 @@
 ---
 title: Dane Wilson
 description: 1 recipe contributed to the Steel Cookbook by Dane Wilson.
+llm: false
 ---
 
 <AuthorProfile handle="danew" name={"Dane Wilson"} avatar="https://github.com/danew.png?size=40" />

--- a/content/docs/cookbook/authors/hussufo.mdx
+++ b/content/docs/cookbook/authors/hussufo.mdx
@@ -1,6 +1,7 @@
 ---
 title: Hussien Hussien
 description: 4 recipes contributed to the Steel Cookbook by Hussien Hussien.
+llm: false
 ---
 
 <AuthorProfile handle="hussufo" name={"Hussien Hussien"} avatar="https://github.com/hussufo.png?size=40" />

--- a/content/docs/cookbook/authors/jagadeshjai.mdx
+++ b/content/docs/cookbook/authors/jagadeshjai.mdx
@@ -1,6 +1,7 @@
 ---
 title: Jagadesh Jai
 description: 4 recipes contributed to the Steel Cookbook by Jagadesh Jai.
+llm: false
 ---
 
 <AuthorProfile handle="jagadeshjai" name={"Jagadesh Jai"} avatar="https://github.com/jagadeshjai.png?size=40" />

--- a/content/docs/cookbook/authors/junhsss.mdx
+++ b/content/docs/cookbook/authors/junhsss.mdx
@@ -1,6 +1,7 @@
 ---
 title: Jun Ryu
 description: 43 recipes contributed to the Steel Cookbook by Jun Ryu.
+llm: false
 ---
 
 <AuthorProfile handle="junhsss" name={"Jun Ryu"} avatar="https://github.com/junhsss.png?size=40" />

--- a/content/docs/cookbook/authors/nibzard.mdx
+++ b/content/docs/cookbook/authors/nibzard.mdx
@@ -1,6 +1,7 @@
 ---
 title: Nikola Balic
 description: 3 recipes contributed to the Steel Cookbook by Nikola Balic.
+llm: false
 ---
 
 <AuthorProfile handle="nibzard" name={"Nikola Balic"} avatar="https://github.com/nibzard.png?size=40" />

--- a/lib/agent-instructions.ts
+++ b/lib/agent-instructions.ts
@@ -65,6 +65,7 @@ export const AGENT_INSTRUCTIONS = `# Steel Documentation
 - The Python package installs as \`pip install steel-sdk\` but imports as \`from steel import Steel\`
 - \`sessions.create()\` accepts an optional \`sessionId\` (Node) / \`session_id\` (Python) UUID when you need the ID before the session exists; omit it and Steel generates one
 - The Python \`sessions.create()\` session timeout param is \`api_timeout\` (not \`timeout\`, which is the HTTP request timeout)
-- Individual doc pages are available as markdown at \`/llms.mdx/<page-path>\`
+- Any docs page is available as markdown by appending \`.md\` to its URL, for example \`https://docs.steel.dev/overview/steel-cli.md\`; AI user agents (Claude, Cursor, GPT) receive markdown automatically at the canonical URL
+- \`/llms-full.txt\` concatenates every page into one file (large, roughly 230k tokens); prefer fetching the individual \`.md\` pages you need over reading the whole bundle
 
 `;

--- a/scripts/sync-cookbook.ts
+++ b/scripts/sync-cookbook.ts
@@ -576,7 +576,9 @@ async function emitAuthorPage(
   const meta = authorMeta(handle, authors);
   const count = matching.length;
   const description = `${count} recipe${count === 1 ? '' : 's'} contributed to the Steel Cookbook by ${meta.name}.`;
-  const fm = frontmatter({ title: meta.name, description });
+  // Author pages are ego listings with little value for coding agents; keep
+  // them out of the llms.txt index and the llms-full.txt bundle.
+  const fm = frontmatter({ title: meta.name, description, llm: 'false' });
   const body = `${renderAuthorProfile(handle, authors)}\n\n${renderRecipeGrid(matching)}`;
   await fs.writeFile(path.join(AUTHORS_DIR, `${handle}.mdx`), `${fm}\n\n${body}\n`);
 }

--- a/tests/cookbook-llm-flags.test.ts
+++ b/tests/cookbook-llm-flags.test.ts
@@ -1,0 +1,33 @@
+// ABOUTME: Guards the LLM-visibility contract for generated cookbook hub pages:
+// ABOUTME: author pages are excluded from agent surfaces, topic pages are kept.
+
+import { describe, expect, test } from 'bun:test';
+import { Glob } from 'bun';
+import matter from 'gray-matter';
+
+async function frontmatter(file: string): Promise<Record<string, unknown>> {
+  return matter(await Bun.file(file).text()).data;
+}
+
+const authors = [
+  ...new Glob('*.mdx').scanSync({ cwd: 'content/docs/cookbook/authors', absolute: true }),
+];
+const topics = [
+  ...new Glob('*.mdx').scanSync({ cwd: 'content/docs/cookbook/topics', absolute: true }),
+];
+
+describe('cookbook hub LLM visibility', () => {
+  test('every author page is excluded from LLM surfaces', async () => {
+    expect(authors.length).toBeGreaterThan(0);
+    for (const file of authors) {
+      expect((await frontmatter(file)).llm).toBe(false);
+    }
+  });
+
+  test('topic pages remain visible to LLMs', async () => {
+    expect(topics.length).toBeGreaterThan(0);
+    for (const file of topics) {
+      expect((await frontmatter(file)).llm).not.toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Two index-hygiene changes for the agent-facing surfaces:

- **Drop cookbook author pages from the LLM index.** Author pages are ego listings ("N recipes contributed by X") with little value for coding agents. They now carry \`llm: false\`, removing ~7 noise links from \`llms.txt\` and excluding them from \`llms-full.txt\`. \`scripts/sync-cookbook.ts\` emits the flag on author pages so the exclusion survives a re-sync. **Topic hubs are kept**: after the markdown-cleanup work (#83) they render as curated recipe link lists, which are useful agent navigation, so they stay in the index.
- **Update agent instructions** to point agents at the \`.md\`-suffix convention (append \`.md\` to any docs URL) instead of the internal \`/llms.mdx/\` path, and to position \`/llms-full.txt\` as a large (~230k-token) corpus to fetch per-page from rather than read whole.

## Notes
- \`sync-cookbook\` regenerates all cookbook files and pulled in unrelated upstream recipe drift; I reverted that and re-applied only the author \`llm: false\` field, so this PR contains no unrelated content changes (and \`cookbook.lock.json\` is left untouched to stay consistent with the reverted content).
- Dropped the planned "Overview Getting Started" title fix: only one page triggers the disambiguation and there's no safe one-line rule (using the page slug would turn "Sessions Api Quickstart" into "Quickstart Quickstart"). The entry has a clear description, so not worth the added generator complexity.

## Testing
- New \`tests/cookbook-llm-flags.test.ts\` guards the contract: every author page has \`llm: false\`, every topic page does not.
- Regenerated \`llms.txt\`: 0 author entries, 18 topic entries retained; new agent-instruction lines present.
- \`bun test tests/\` (201 pass), Biome (\`--error-on-warnings\`), \`tsc --noEmit\`, \`bun run build\` all clean.