### PR TITLE
fix(llms): serve markdown in place at the docs root

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -38,10 +38,13 @@ export default function middleware(request: NextRequest) {
 
   const wantsMarkdown = shouldServeMarkdown(request.headers);
 
+  // The homepage has no MDX page behind it, so markdown clients get the agent
+  // guide, which opens with a pointer to the /llms.txt index. Serving it in
+  // place keeps negotiation on the requested URL instead of redirecting away.
   if (pathname === '/' && (wantsMarkdown || isProgrammaticClient(request))) {
-    const redirectUrl = request.nextUrl.clone();
-    redirectUrl.pathname = '/llms.txt';
-    return withMarkdownVary(NextResponse.redirect(redirectUrl));
+    const rewriteUrl = request.nextUrl.clone();
+    rewriteUrl.pathname = '/AGENTS.md';
+    return withMarkdownVary(NextResponse.rewrite(rewriteUrl));
   }
 
   if (!isNegotiableDocsPath(pathname)) {

--- a/tests/e2e/llm-endpoints.test.ts
+++ b/tests/e2e/llm-endpoints.test.ts
@@ -101,6 +101,16 @@ describe('.md suffix end-to-end', () => {
     expect(await response.text()).not.toContain('Full docs index');
   });
 
+  test('negotiates markdown at the homepage without redirecting', async () => {
+    const response = await fetch(BASE_URL, {
+      headers: { accept: 'text/markdown' },
+      redirect: 'manual',
+    });
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toStartWith('text/markdown');
+    expect(await response.text()).toStartWith('> Full docs index: https://docs.steel.dev/llms.txt');
+  });
+
   test('returns 404 for a .md URL with no matching page', async () => {
     const response = await fetch(`${BASE_URL}/nonexistent-page.md`, {
       headers: BROWSER_HEADERS,

--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -42,6 +42,35 @@ describe('middleware .md suffix handling', () => {
     expect(response.headers.get('x-middleware-rewrite')).toBeNull();
   });
 
+  test('serves the homepage as markdown in place, without a redirect', () => {
+    const response = middleware(
+      new NextRequest('http://localhost/', { headers: { accept: 'text/markdown' } }),
+    );
+    const rewrite = response.headers.get('x-middleware-rewrite');
+    expect(rewrite).not.toBeNull();
+    expect(new URL(rewrite as string).pathname).toBe('/AGENTS.md');
+    expect(response.status).toBe(200);
+    expect(response.headers.get('location')).toBeNull();
+    expect(response.headers.get('Vary')).toContain('Accept');
+  });
+
+  test('serves the homepage as markdown to programmatic clients', () => {
+    const response = middleware(
+      new NextRequest('http://localhost/', {
+        headers: { accept: 'text/html', 'user-agent': 'curl/8.7.1' },
+      }),
+    );
+    const rewrite = response.headers.get('x-middleware-rewrite');
+    expect(rewrite).not.toBeNull();
+    expect(new URL(rewrite as string).pathname).toBe('/AGENTS.md');
+  });
+
+  test('leaves the homepage untouched for browsers', () => {
+    const response = middleware(browserRequest('http://localhost/'));
+    expect(response.headers.get('x-middleware-rewrite')).toBeNull();
+    expect(response.headers.get('location')).toBeNull();
+  });
+
   test('does not rewrite /AGENTS.md, even for markdown user agents', () => {
     const browser = middleware(browserRequest('http://localhost/AGENTS.md'));
     expect(browser.headers.get('x-middleware-rewrite')).toBeNull();


### PR DESCRIPTION
## Problem

`isitagentready.com` scores `checks.contentAccessibility.markdownNegotiation` as **fail** for docs.steel.dev:

```
GET / with Accept: text/markdown
  307 -> /llms.txt
  content-type: text/plain; charset=utf-8   <- fail
```

The scanner only probes the homepage. `middleware.ts` redirected `/` to `/llms.txt`, and Vercel serves `public/llms.txt` as `text/plain`, so the final response never carried a markdown content type. Every other negotiation path was already correct (`/overview/intro-to-steel` and `/overview/intro-to-steel.md` both return `text/markdown; charset=utf-8`).

## Change

Rewrite instead of redirect: `/` with markdown intent now serves `/AGENTS.md` in place, which returns `200 text/markdown` and opens with `> Full docs index: https://docs.steel.dev/llms.txt`. Content negotiation stays on the requested URL, and agents still reach the index in one hop.

## Verification

Production build (`bun run build && next start`):

| Request | Before | After |
| --- | --- | --- |
| `GET /` + `Accept: text/markdown` | 307 -> `/llms.txt`, `text/plain` | 200, `text/markdown; charset=utf-8` |
| `GET /` from curl | 307 -> `/llms.txt`, `text/plain` | 200, `text/markdown; charset=utf-8` |
| `GET /` from a browser | 307 -> `/overview` | 307 -> `/overview` (unchanged) |

Tests: 3 new middleware cases plus one e2e case covering the root; full suite 209 pass / 0 fail; `bun run check` clean.

## Follow-up, not in this PR

Negotiable docs URLs answer with HTML or markdown but their `Vary` does not list `Accept` or `User-Agent` on prerendered pages. Next's app router calls `setVaryHeader` itself and discards values set via `next.config.mjs` headers (verified: a probe header on the same rule applied, `Vary` did not), so fixing it needs the Vercel routing layer and a preview deploy to verify. Vercel's own cache keys after middleware runs, so the exposure is limited to downstream shared caches.