### PR TITLE
fix(tests): give the Chromium imagegen suites room on CI

### DIFF
--- a/tests/imagegen/e2e/cli.test.ts
+++ b/tests/imagegen/e2e/cli.test.ts
@@ -8,8 +8,9 @@ import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { PNG } from 'pngjs';
 
-// Each case renders a card in a subprocess, which exceeds the default 5s timeout.
-setDefaultTimeout(30000);
+// Each case renders a card in a subprocess, launching headless Chromium, which is
+// slow enough on a loaded two-core CI runner to blow past a 30s budget.
+setDefaultTimeout(120000);
 
 const CLI = fileURLToPath(new URL('../../../scripts/changelog/imagegen/cli.ts', import.meta.url));
 

--- a/tests/imagegen/integration/render.test.ts
+++ b/tests/imagegen/integration/render.test.ts
@@ -4,8 +4,9 @@ import { beforeAll, describe, setDefaultTimeout, test } from 'bun:test';
 import assert from 'node:assert/strict';
 import { PNG } from 'pngjs';
 
-// The render hook launches headless Chromium, which can exceed the default 5s on CI.
-setDefaultTimeout(30000);
+// The render hook launches headless Chromium, which is slow enough on a loaded
+// two-core CI runner to blow past a 30s budget.
+setDefaultTimeout(120000);
 
 import { renderCard } from '../../../scripts/changelog/imagegen/render';
 import { CARD_HEIGHT, CARD_WIDTH } from '../../../scripts/changelog/imagegen/template';

--- a/tests/imagegen/integration/run.test.ts
+++ b/tests/imagegen/integration/run.test.ts
@@ -4,8 +4,9 @@ import { afterAll, beforeAll, describe, setDefaultTimeout, test } from 'bun:test
 import assert from 'node:assert/strict';
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 
-// The pipeline renders with headless Chromium, which can exceed the default 5s on CI.
-setDefaultTimeout(30000);
+// The pipeline launches a fresh headless Chromium per render. On a loaded
+// two-core CI runner one launch has taken over 30s, so allow generous headroom.
+setDefaultTimeout(120000);
 
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';


### PR DESCRIPTION
## Problem

CI run [#376](https://github.com/steel-dev/docs/actions/runs/30533524742) failed on the PR branch for #86:

```
1 tests failed:
(fail) run (generate path) > keeps the undithered original alongside the card [30000.34ms]
  ^ this test timed out after 30000ms.
 208 pass, 1 fail
```

The test is unrelated to that PR's change, and the same suite passed on the main push run minutes later, so it is a flake rather than a regression.

## Diagnosis

`renderCard` launches a fresh headless Chromium per render and closes it in a `finally`, so nothing leaks. Fonts are inlined as data URIs and the OpenAI call is stubbed, so neither the network nor an external service is in the path. What is left is CPU: on a two-core GitHub runner, with the other suites in the same `bun test` invocation competing (including one that boots a Next dev server), a single Chromium launch can exceed 30s.

Two supporting details:

- The first test in the file, which also renders, passed. It was the second launch that timed out, which points at contention rather than a cold start.
- Locally the whole `run.test.ts` file finishes in **1.8s**, a 16x margin under the old ceiling. A budget that generous locally and still failing on CI is a budget set against the wrong machine.

## Change

Raise `setDefaultTimeout` from 30s to 120s in the three Chromium-backed suites (`imagegen/integration/run`, `imagegen/integration/render`, `imagegen/e2e/cli`), matching what `tests/e2e/llm-endpoints.test.ts` already uses for its dev server. These tests do not hang, so the higher ceiling costs nothing on a healthy run and only buys headroom on a slow one.

## Verification

`bun test` 209 pass / 0 fail, `bun run check` clean, `bun run typecheck` clean.

## Separate flake, not addressed here

While running `bun test tests/imagegen` under load I hit a different intermittent failure, three cases in `imagegen/e2e/cli.test.ts` dying on `TypeError: undefined is not an object (evaluating 'result.stdout.toString')`, meaning `Bun.spawnSync` came back with no stdout. It reproduces independently of this change and the file already carries a comment about async spawns deadlocking once the Chromium tests have run in the same process. Repeat runs of the same directory on both main and this branch came back clean, so it needs its own investigation rather than a blind fix.