### PR TITLE
docs(seo): scope Railway self-hosting page to Steel

### DIFF
--- a/content/docs/overview/self-hosting/railway.mdx
+++ b/content/docs/overview/self-hosting/railway.mdx
@@ -1,16 +1,16 @@
 ---
-title: Railway
+title: Self-Host Steel Browser on Railway
 sidebarTitle: Railway
-description: A quick guide on deploying Steel Browser to Railway using our template
+description: "Self-host Steel Browser on Railway with our one-click deploy template: launch the container, verify the /v1/health endpoint, and connect over CDP."
 full: true
 llm: true
 ---
 [Deploy the Template on Railway ↗](https://railway.com/deploy/steelbrowser?referralCode=Jwc4kg&utm_medium=integration&utm_source=template&utm_campaign=generic)
 
 ### Overview
-Hosting Steel Browser on Railway provides a reliable, scalable environment for running headless Chrome instances. The Steel Browser API handles browser session management, proxy configuration, and CDP passthroughs while Railway provides extremely easy APIs to scale and handles resource allocation automatically. Running Steel Browser on Railway's infrastructure ensures your browser automations run consistently with minimal configuration, while providing automatic scaling and health monitoring for production workloads.
+Self-hosting Steel Browser on Railway provides a reliable, scalable environment for running headless Chrome instances. The Steel Browser API handles browser session management, proxy configuration, and CDP passthroughs while Railway provides extremely easy APIs to scale and handles resource allocation automatically. Running Steel Browser on Railway's infrastructure ensures your browser automations run consistently with minimal configuration, while providing automatic scaling and health monitoring for production workloads.
 
-### Common Use Cases
+### Common Use Cases for Self-Hosted Steel Browser
 - **Web Scraping:** Extract data from dynamic websites that require JavaScript rendering
 - **Browser Automation:** Automate repetitive web tasks and workflows
 - **End-to-End Testing:** Run automated browser tests for web applications
@@ -29,9 +29,9 @@ Hosting Steel Browser on Railway provides a reliable, scalable environment for r
 
 ### Implementation Details
 
-**Health Check Endpoint:**
+**Steel Browser Health Check Endpoint:**
 
-Verify your instance is running:
+Verify your Steel Browser instance is running:
 
 ```bash Terminal -wcn
 curl https://your-domain.railway.app/v1/health
@@ -65,16 +65,16 @@ By deploying Steel Browser on Railway, you are one step closer to supporting a c
 - Simple environment variable management
 - Seamless integration with other Railway services
 
-### Post-Deployment Notes
+### After Deploying Steel Browser
 
 After deploying this template, users should:
 
-1. **Access the Instance:** Navigate to the Railway-provided public domain
+1. **Access Your Steel Instance:** Navigate to the Railway-provided public domain
 2. **Verify Health:** Check the `/v1/health` endpoint returns a successful response
 3. **Configure API Access:** Use the public domain URL in their application code
 4. **Monitor Usage:** Check Railway's metrics dashboard for resource usage
 
-### Security Considerations:
+### Securing Your Steel Browser Instance
 - Consider adding authentication if exposing publicly
 - Monitor for unusual traffic patterns
 - Set up rate limiting if needed for production use


### PR DESCRIPTION
## Why

Google Search Console shows `/overview/self-hosting/railway` earning **36,672 impressions (17.6% of site total) at 0.05% CTR**. The impressions come from Railway-the-platform queries Steel can never win:

- `railway healthcheckpath railway.json docs`
- `railway autoscaling documentation`
- `railway public domain up.railway.app docs`
- `railway dev`
- `railway web`

The page was titled just "Railway", so Google treated it as generic Railway platform documentation. This scopes it unambiguously to self-hosting Steel Browser on Railway, following the intent-phrased title/meta convention from #72.

## What changed

**Frontmatter**

| | Before | After |
|---|---|---|
| `title` | `Railway` | `Self-Host Steel Browser on Railway` |
| `description` | `A quick guide on deploying Steel Browser to Railway using our template` | `Self-host Steel Browser on Railway with our one-click deploy template: launch the container, verify the /v1/health endpoint, and connect over CDP.` (146 chars) |

`sidebarTitle: Railway` is unchanged, so the sidebar label stays short.

**Headings and labels rescoped away from generic Railway phrasing**

- `### Common Use Cases` -> `### Common Use Cases for Self-Hosted Steel Browser`
- `**Health Check Endpoint:**` -> `**Steel Browser Health Check Endpoint:**` (the `railway healthcheckpath` match)
- `### Post-Deployment Notes` -> `### After Deploying Steel Browser`
- `1. **Access the Instance:**` -> `1. **Access Your Steel Instance:**` (the `railway public domain` match)
- `### Security Considerations:` -> `### Securing Your Steel Browser Instance`
- Opening paragraph: "Hosting Steel Browser on Railway" -> "Self-hosting Steel Browser on Railway"

No body content was restructured and no inbound links or anchors pointed at the renamed headings.

## Verification

- `bun run lint` clean
- `bun run validate-links` 0 errors
- `bun run generate && bun run build` succeeds; rendered `<title>` is `Self-Host Steel Browser on Railway | Steel Docs` with the new meta description
