### PR TITLE
feat(seo): noindex LLM text endpoints

### DIFF
--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -13,6 +13,10 @@ export async function GET() {
   const scanned = await Promise.all(scan);
 
   return new Response(AGENT_INSTRUCTIONS + scanned.join('\n\n'), {
-    headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      // A dump of every docs page: fetchable by agents, but not a search result.
+      'X-Robots-Tag': 'noindex',
+    },
   });
 }

--- a/app/llms.mdx/[[...slug]]/route.ts
+++ b/app/llms.mdx/[[...slug]]/route.ts
@@ -20,7 +20,12 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ slu
   const page = getPage(slug);
   if (!page) notFound();
 
-  const headers = new Headers({ 'Content-Type': 'text/markdown; charset=utf-8' });
+  // This markdown duplicates the canonical HTML page, so keep it out of search
+  // results. Crawlers may still fetch it: noindex only suppresses indexing.
+  const headers = new Headers({
+    'Content-Type': 'text/markdown; charset=utf-8',
+    'X-Robots-Tag': 'noindex',
+  });
   appendMarkdownVaryHeader(headers);
 
   return new NextResponse(await getLLMText(page, { indexPointer: true }), {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -221,6 +221,28 @@ const config = {
         ],
       },
       {
+        // Plain-text mirrors of the docs. Agents should fetch them; Google
+        // should not list them next to the HTML pages they duplicate. Matching
+        // happens on the requested path, so the homepage keeps its own headers
+        // when middleware rewrites it to /AGENTS.md for markdown clients.
+        source: "/:path*/llms.txt",
+        headers: [
+          {
+            key: "X-Robots-Tag",
+            value: "noindex",
+          },
+        ],
+      },
+      {
+        source: "/AGENTS.md",
+        headers: [
+          {
+            key: "X-Robots-Tag",
+            value: "noindex",
+          },
+        ],
+      },
+      {
         source: "/(.*)",
         headers: [
           {

--- a/tests/e2e/llm-endpoints.test.ts
+++ b/tests/e2e/llm-endpoints.test.ts
@@ -95,6 +95,34 @@ describe('.md suffix end-to-end', () => {
     expect(response.headers.get('location')).toBe('/AGENTS.md');
   });
 
+  test('marks a .md docs URL noindex while its canonical HTML page stays indexable', async () => {
+    const markdown = await fetch(`${BASE_URL}/overview/sessions-api/quickstart.md`, {
+      headers: BROWSER_HEADERS,
+    });
+    expect(markdown.headers.get('x-robots-tag')).toContain('noindex');
+
+    const html = await fetch(`${BASE_URL}/overview/sessions-api/quickstart`, {
+      headers: BROWSER_HEADERS,
+    });
+    expect(html.headers.get('x-robots-tag')).toBeNull();
+  });
+
+  test('marks the plain-text agent endpoints noindex', async () => {
+    // Status is not asserted: /llms.txt is generated into public/ at build
+    // time, so it is absent when tests run. The header comes from the route
+    // config either way, which is what matters for crawlers.
+    for (const path of ['/llms.txt', '/llms-full.txt', '/AGENTS.md']) {
+      const response = await fetch(`${BASE_URL}${path}`, { headers: BROWSER_HEADERS });
+      expect(response.headers.get('x-robots-tag')).toContain('noindex');
+    }
+  });
+
+  test('keeps the homepage indexable when it negotiates markdown', async () => {
+    const response = await fetch(BASE_URL, { headers: { accept: 'text/markdown' } });
+    expect(response.headers.get('content-type')).toStartWith('text/markdown');
+    expect(response.headers.get('x-robots-tag')).toBeNull();
+  });
+
   test('llms-full.txt does not repeat the index pointer', async () => {
     const response = await fetch(`${BASE_URL}/llms-full.txt`, { headers: BROWSER_HEADERS });
     expect(response.status).toBe(200);


### PR DESCRIPTION
## Problem

The plain-text mirrors of the docs are ranking against the HTML pages they duplicate. Search Console shows `/llms-full.txt` with 37,527 impressions (18% of the site's total) at average position 17.9 and a 0.03% CTR: a raw text dump shown to human searchers, dragging the site-wide CTR baseline down.

## Change

`X-Robots-Tag: noindex` on every alternate-format endpoint, using whichever mechanism owns the response:

| Endpoint | Mechanism |
| --- | --- |
| `/llms.txt` and per-section `*/llms.txt` | `headers()` in `next.config.mjs` (static files in `public/`) |
| `/AGENTS.md` | `headers()` in `next.config.mjs` |
| `/llms-full.txt` | route handler (`app/llms-full.txt/route.ts`) |
| `/llms.mdx/*` and every `.md`-suffixed docs URL | route handler (`app/llms.mdx/[[...slug]]/route.ts`), which middleware rewrites `.md` URLs into |

Crawling is untouched: `robots.txt` still allows everything and no `Disallow` was added, so agents keep fetching these exactly as before. Only indexing is suppressed.

`/AGENTS.md` gets its header from `next.config.mjs` rather than from its route handler on purpose. Middleware rewrites `/` to `/AGENTS.md` for markdown and programmatic clients, and header matching happens on the requested path, so the homepage keeps its own headers instead of inheriting `noindex`. No HTML page is noindexed.

## Test evidence

TDD: the two new header assertions in `tests/e2e/llm-endpoints.test.ts` failed first (`x-robots-tag` was `null`), then passed after the implementation. A third test pins the homepage as indexable even when it negotiates markdown.

- `bun test tests/e2e/llm-endpoints.test.ts`: 14 pass, 0 fail
- `bun test` (full suite): 230 pass, 0 fail
- `bun run lint` clean, `bun run typecheck` clean

Manual probe against `next dev` with the generated `llms.txt` files present:

```
/llms.txt                             200 | noindex
/overview/llms.txt                    200 | noindex
/overview/sessions-api/llms.txt       200 | noindex
/llms-full.txt                        200 | noindex
/AGENTS.md                            200 | noindex
/llms.mdx/overview/steel-cli          200 | noindex
/overview/sessions-api/quickstart.md  200 | noindex
/overview/sessions-api/quickstart     200 | none
/robots.txt                           200 | none
/sitemap.xml                          200 | none
/  (also with accept: text/markdown)  200 | none
```
