### PR TITLE
fix(llms): serve canonical HTML to crawlers

### DIFF
--- a/lib/markdown-negotiation.ts
+++ b/lib/markdown-negotiation.ts
@@ -5,14 +5,7 @@ const MARKDOWN_ACCEPT_TYPES = new Set([
   'text/vnd.daringfireball.markdown',
 ]);
 
-export const EXACT_MARKDOWN_USER_AGENTS = [
-  'anthropic-ai',
-  'chatgpt-user',
-  'claudebot',
-  'gptbot',
-  'oai-searchbot',
-  'perplexitybot',
-];
+export const EXACT_MARKDOWN_USER_AGENTS = ['chatgpt-user', 'claude-user', 'perplexity-user'];
 
 export const MARKDOWN_USER_AGENT_SUBSTRINGS = [
   'anthropic',
@@ -21,11 +14,19 @@ export const MARKDOWN_USER_AGENT_SUBSTRINGS = [
   'copilot',
   'cursor',
   'gemini',
-  'gptbot',
   'mistral',
-  'oai-searchbot',
   'openai',
   'perplexity',
+];
+
+const HTML_CRAWLER_USER_AGENT_SUBSTRINGS = [
+  'anthropic-ai',
+  'claudebot',
+  'claude-searchbot',
+  'gptbot',
+  'oai-adsbot',
+  'oai-searchbot',
+  'perplexitybot',
 ];
 
 const MARKDOWN_VARY_HEADERS = ['Accept', 'User-Agent'];
@@ -36,6 +37,8 @@ const EXCLUDED_EXACT_PATHS = new Set([
   '/favicon.ico',
   '/llms-full.txt',
   '/llms.txt',
+  '/overview',
+  '/overview/',
   '/overview/llms-full.txt',
   '/robots.txt',
   '/sitemap.xml',
@@ -126,6 +129,12 @@ export function isMarkdownUserAgent(userAgentHeader: string | null): boolean {
   if (!userAgentHeader) return false;
 
   const userAgent = normalizeUserAgent(userAgentHeader);
+
+  // Canonical crawler requests need indexable HTML. Explicit Markdown Accept
+  // headers are handled separately in shouldServeMarkdown and still take priority.
+  if (HTML_CRAWLER_USER_AGENT_SUBSTRINGS.some((match) => userAgent.includes(match))) {
+    return false;
+  }
 
   return (
     EXACT_MARKDOWN_USER_AGENTS.includes(userAgent) ||

--- a/middleware.ts
+++ b/middleware.ts
@@ -7,11 +7,6 @@ import {
   shouldServeMarkdown,
 } from '@/lib/markdown-negotiation';
 
-function isProgrammaticClient(request: NextRequest): boolean {
-  // Browsers always send Sec-Fetch-Dest; curl/WebFetch/python-requests do not
-  return !request.headers.has('sec-fetch-dest');
-}
-
 function isNegotiableMethod(method: string): boolean {
   return method === 'GET' || method === 'HEAD';
 }
@@ -38,13 +33,16 @@ export default function middleware(request: NextRequest) {
 
   const wantsMarkdown = shouldServeMarkdown(request.headers);
 
-  // The homepage has no MDX page behind it, so markdown clients get the agent
-  // guide, which opens with a pointer to the /llms.txt index. Serving it in
-  // place keeps negotiation on the requested URL instead of redirecting away.
-  if (pathname === '/' && (wantsMarkdown || isProgrammaticClient(request))) {
-    const rewriteUrl = request.nextUrl.clone();
-    rewriteUrl.pathname = '/AGENTS.md';
-    return withMarkdownVary(NextResponse.rewrite(rewriteUrl));
+  if (pathname === '/') {
+    // The homepage has no MDX page behind it, so Markdown clients get the agent
+    // guide in place. Every other client follows the canonical HTML route.
+    if (wantsMarkdown) {
+      const rewriteUrl = request.nextUrl.clone();
+      rewriteUrl.pathname = '/AGENTS.md';
+      return withMarkdownVary(NextResponse.rewrite(rewriteUrl));
+    }
+
+    return withMarkdownVary(NextResponse.redirect(new URL('/overview', request.url)));
   }
 
   if (!isNegotiableDocsPath(pathname)) {

--- a/tests/e2e/llm-endpoints.test.ts
+++ b/tests/e2e/llm-endpoints.test.ts
@@ -16,7 +16,30 @@ const BROWSER_HEADERS = {
   'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Safari/605.1.15',
 };
 
+const HTML_CRAWLER_USER_AGENTS = [
+  'Mozilla/5.0 AppleWebKit/537.36; compatible; GPTBot/1.4; +https://openai.com/gptbot',
+  'Mozilla/5.0 AppleWebKit/537.36; compatible; OAI-AdsBot/1.0; +https://openai.com/adsbot',
+  'Mozilla/5.0 AppleWebKit/537.36; compatible; OAI-SearchBot/1.4; +https://openai.com/searchbot',
+  'ClaudeBot/1.0',
+  'Claude-SearchBot/1.0',
+  'Mozilla/5.0 AppleWebKit/537.36; compatible; PerplexityBot/1.0; +https://perplexity.ai/perplexitybot',
+];
+
+const MARKDOWN_USER_AGENTS = [
+  'ChatGPT-User/1.0',
+  'Claude-User/1.0',
+  'Perplexity-User/1.0',
+  'claude-code/1.0',
+];
+
 let server: ReturnType<typeof Bun.spawn>;
+
+function varyTokens(response: Response): string[] {
+  return (response.headers.get('Vary') ?? '')
+    .split(',')
+    .map((value) => value.trim().toLowerCase())
+    .filter(Boolean);
+}
 
 async function waitForServer(): Promise<void> {
   const deadline = Date.now() + 90000;
@@ -136,7 +159,64 @@ describe('.md suffix end-to-end', () => {
     });
     expect(response.status).toBe(200);
     expect(response.headers.get('content-type')).toStartWith('text/markdown');
+    expect(varyTokens(response)).toEqual(expect.arrayContaining(['accept', 'user-agent']));
     expect(await response.text()).toStartWith('> Full docs index: https://docs.steel.dev/llms.txt');
+  });
+
+  test('serves canonical HTML without noindex to AI crawlers', async () => {
+    for (const userAgent of HTML_CRAWLER_USER_AGENTS) {
+      for (const path of ['/overview', '/overview/sessions-api/quickstart']) {
+        const response = await fetch(`${BASE_URL}${path}`, {
+          headers: { accept: 'text/html', 'user-agent': userAgent },
+        });
+        expect(response.status).toBe(200);
+        expect(response.headers.get('content-type')).toStartWith('text/html');
+        expect(response.headers.get('x-robots-tag')).toBeNull();
+      }
+    }
+  });
+
+  test('keeps the HTML-only overview available to Markdown clients', async () => {
+    const headersToTest = [
+      ...MARKDOWN_USER_AGENTS.map((userAgent) => ({
+        accept: 'text/html',
+        'user-agent': userAgent,
+      })),
+      { accept: 'text/markdown', 'user-agent': 'curl/8.7.1' },
+    ];
+
+    for (const headers of headersToTest) {
+      const response = await fetch(`${BASE_URL}/overview`, { headers });
+      expect(response.status).toBe(200);
+      expect(response.headers.get('content-type')).toStartWith('text/html');
+      expect(response.headers.get('x-robots-tag')).toBeNull();
+    }
+  });
+
+  test('keeps Markdown negotiation for user-directed clients on regular docs', async () => {
+    for (const userAgent of MARKDOWN_USER_AGENTS) {
+      const response = await fetch(`${BASE_URL}/overview/sessions-api/quickstart`, {
+        headers: { accept: 'text/html', 'user-agent': userAgent },
+      });
+      expect(response.status).toBe(200);
+      expect(response.headers.get('content-type')).toStartWith('text/markdown');
+      expect(response.headers.get('x-robots-tag')).toContain('noindex');
+    }
+  });
+
+  test('redirects crawler and generic root requests to the HTML overview', async () => {
+    for (const userAgent of ['curl/8.7.1', ...HTML_CRAWLER_USER_AGENTS]) {
+      const response = await fetch(BASE_URL, {
+        headers: { accept: 'text/html', 'user-agent': userAgent },
+        redirect: 'manual',
+      });
+      expect(response.status).toBe(307);
+      expect(new URL(response.headers.get('location') as string, BASE_URL).pathname).toBe(
+        '/overview',
+      );
+      expect(response.headers.get('content-type')).not.toStartWith('text/markdown');
+      expect(varyTokens(response)).toEqual(expect.arrayContaining(['accept', 'user-agent']));
+    }
   });
 
   test('serves the API catalog as a linkset', async () => {

--- a/tests/markdown-negotiation.test.ts
+++ b/tests/markdown-negotiation.test.ts
@@ -1,7 +1,11 @@
-// ABOUTME: Tests for resolveMarkdownPath, which maps .md-suffixed docs URLs
-// ABOUTME: to their canonical path so middleware can serve the markdown version.
+// ABOUTME: Tests Markdown content negotiation, path eligibility, and explicit
+// ABOUTME: .md URL mapping for the docs middleware.
 import { describe, expect, test } from 'bun:test';
-import { isNegotiableDocsPath, resolveMarkdownPath } from '../lib/markdown-negotiation';
+import {
+  isNegotiableDocsPath,
+  resolveMarkdownPath,
+  shouldServeMarkdown,
+} from '../lib/markdown-negotiation';
 
 describe('resolveMarkdownPath', () => {
   test('strips .md from a docs page path', () => {
@@ -32,6 +36,10 @@ describe('resolveMarkdownPath', () => {
     expect(resolveMarkdownPath('/AGENTS.md')).toBeNull();
   });
 
+  test('returns null for /overview.md while the React landing page has no Markdown source', () => {
+    expect(resolveMarkdownPath('/overview.md')).toBeNull();
+  });
+
   test('returns null when the stripped path is under an excluded prefix', () => {
     expect(resolveMarkdownPath('/llms.mdx/overview.md')).toBeNull();
     expect(resolveMarkdownPath('/api/search.md')).toBeNull();
@@ -44,6 +52,11 @@ describe('resolveMarkdownPath', () => {
 });
 
 describe('isNegotiableDocsPath', () => {
+  test('keeps the React overview landing page HTML-only', () => {
+    expect(isNegotiableDocsPath('/overview')).toBe(false);
+    expect(isNegotiableDocsPath('/overview/')).toBe(false);
+  });
+
   test('excludes Agent Skills discovery artifacts from markdown rewrites', () => {
     expect(isNegotiableDocsPath('/.well-known/agent-skills/index.json')).toBe(false);
     expect(isNegotiableDocsPath('/.well-known/agent-skills/steel-browser.tar.gz')).toBe(false);
@@ -62,5 +75,44 @@ describe('isNegotiableDocsPath', () => {
     expect(isNegotiableDocsPath('/downloads/starter.tgz')).toBe(false);
     expect(isNegotiableDocsPath('/downloads/starter.tar')).toBe(false);
     expect(isNegotiableDocsPath('/downloads/starter.zip')).toBe(false);
+  });
+});
+
+describe('shouldServeMarkdown', () => {
+  test.each([
+    'anthropic-ai',
+    'ClaudeBot/1.0',
+    'Claude-SearchBot/1.0',
+    'Mozilla/5.0 AppleWebKit/537.36; compatible; GPTBot/1.4; +https://openai.com/gptbot',
+    'Mozilla/5.0 AppleWebKit/537.36; compatible; OAI-AdsBot/1.0; +https://openai.com/adsbot',
+    'Mozilla/5.0 AppleWebKit/537.36; compatible; OAI-SearchBot/1.4; +https://openai.com/searchbot',
+    'Mozilla/5.0 AppleWebKit/537.36; compatible; PerplexityBot/1.0; +https://perplexity.ai/perplexitybot',
+  ])('defaults the %s crawler to canonical HTML', (userAgent) => {
+    const headers = new Headers({ accept: 'text/html', 'user-agent': userAgent });
+    expect(shouldServeMarkdown(headers)).toBe(false);
+  });
+
+  test.each(['ChatGPT-User/1.0', 'Claude-User/1.0', 'Perplexity-User/1.0', 'claude-code/1.0'])(
+    'serves Markdown to the user-directed client %s',
+    (userAgent) => {
+      const headers = new Headers({ accept: 'text/html', 'user-agent': userAgent });
+      expect(shouldServeMarkdown(headers)).toBe(true);
+    },
+  );
+
+  test('honors an explicit Markdown Accept header from any client', () => {
+    const headers = new Headers({
+      accept: 'text/markdown',
+      'user-agent': 'OAI-SearchBot/1.0',
+    });
+    expect(shouldServeMarkdown(headers)).toBe(true);
+  });
+
+  test('ignores a zero-quality Markdown Accept value for a crawler', () => {
+    const headers = new Headers({
+      accept: 'text/markdown;q=0, text/html',
+      'user-agent': 'OAI-SearchBot/1.4',
+    });
+    expect(shouldServeMarkdown(headers)).toBe(false);
   });
 });

--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -1,5 +1,5 @@
-// ABOUTME: Integration tests for the docs middleware, verifying .md-suffixed
-// ABOUTME: URLs rewrite to the /llms.mdx markdown route and others pass through.
+// ABOUTME: Integration tests for docs middleware Markdown rewrites and canonical
+// ABOUTME: HTML routing.
 import { describe, expect, test } from 'bun:test';
 import { NextRequest } from 'next/server';
 import middleware from '../middleware';
@@ -12,6 +12,13 @@ function browserRequest(url: string): NextRequest {
       'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Safari/605.1.15',
     },
   });
+}
+
+function varyTokens(response: Response): string[] {
+  return (response.headers.get('Vary') ?? '')
+    .split(',')
+    .map((value) => value.trim().toLowerCase())
+    .filter(Boolean);
 }
 
 describe('middleware .md suffix handling', () => {
@@ -37,6 +44,20 @@ describe('middleware .md suffix handling', () => {
     expect(response.headers.get('x-middleware-rewrite')).toBeNull();
   });
 
+  test.each([
+    { accept: 'text/html', 'user-agent': 'ChatGPT-User/1.0' },
+    { accept: 'text/markdown', 'user-agent': 'curl/8.7.1' },
+  ])('keeps the HTML-only overview landing page out of negotiation', (headers) => {
+    for (const pathname of ['/overview', '/overview/']) {
+      const response = middleware(
+        new NextRequest(`http://localhost${pathname}`, {
+          headers,
+        }),
+      );
+      expect(response.headers.get('x-middleware-rewrite')).toBeNull();
+    }
+  });
+
   test('does not rewrite excluded .md paths', () => {
     const response = middleware(browserRequest('http://localhost/llms-full.txt.md'));
     expect(response.headers.get('x-middleware-rewrite')).toBeNull();
@@ -51,13 +72,13 @@ describe('middleware .md suffix handling', () => {
     expect(new URL(rewrite as string).pathname).toBe('/AGENTS.md');
     expect(response.status).toBe(200);
     expect(response.headers.get('location')).toBeNull();
-    expect(response.headers.get('Vary')).toContain('Accept');
+    expect(varyTokens(response)).toEqual(expect.arrayContaining(['accept', 'user-agent']));
   });
 
-  test('serves the homepage as markdown to programmatic clients', () => {
+  test('serves the homepage as markdown to user-directed agent clients', () => {
     const response = middleware(
       new NextRequest('http://localhost/', {
-        headers: { accept: 'text/html', 'user-agent': 'curl/8.7.1' },
+        headers: { accept: 'text/html', 'user-agent': 'claude-code/1.0' },
       }),
     );
     const rewrite = response.headers.get('x-middleware-rewrite');
@@ -65,10 +86,32 @@ describe('middleware .md suffix handling', () => {
     expect(new URL(rewrite as string).pathname).toBe('/AGENTS.md');
   });
 
-  test('leaves the homepage untouched for browsers', () => {
+  test.each([
+    'curl/8.7.1',
+    'Googlebot/2.1',
+    'GPTBot/1.2',
+    'OAI-AdsBot/1.0',
+    'OAI-SearchBot/1.0',
+    'ClaudeBot/1.0',
+    'Claude-SearchBot/1.0',
+    'PerplexityBot/1.0',
+  ])('redirects the non-Markdown root request from %s to HTML', (userAgent) => {
+    const response = middleware(
+      new NextRequest('http://localhost/', {
+        headers: { accept: 'text/html', 'user-agent': userAgent },
+      }),
+    );
+    expect(response.headers.get('x-middleware-rewrite')).toBeNull();
+    expect(response.status).toBe(307);
+    expect(new URL(response.headers.get('location') as string).pathname).toBe('/overview');
+    expect(varyTokens(response)).toEqual(expect.arrayContaining(['accept', 'user-agent']));
+  });
+
+  test('redirects browser navigation at the homepage to HTML', () => {
     const response = middleware(browserRequest('http://localhost/'));
     expect(response.headers.get('x-middleware-rewrite')).toBeNull();
-    expect(response.headers.get('location')).toBeNull();
+    expect(response.status).toBe(307);
+    expect(new URL(response.headers.get('location') as string).pathname).toBe('/overview');
   });
 
   test('does not rewrite /AGENTS.md, even for markdown user agents', () => {


### PR DESCRIPTION
## Summary

- serve canonical, indexable HTML to autonomous AI crawlers by default
- preserve Markdown negotiation for user-directed fetchers, coding agents, explicit Markdown `Accept` headers, and `.md` URLs
- keep `/overview` HTML-only because it has no equivalent MDX source
- route non-Markdown `/` requests to `/overview` and preserve `Vary: Accept, User-Agent`
- add unit, middleware, and runtime regression coverage for the crawler/client matrix

## Why

Autonomous crawler user agents were grouped with Markdown clients. Canonical requests were therefore rewritten to Markdown responses carrying `X-Robots-Tag: noindex`; `/overview` was worse because it has no Fumadocs source, so the rewrite returned 404. The root route also treated every request without `Sec-Fetch-Dest` as Markdown, including crawlers and generic HTTP clients.

## Impact

Search and training crawlers now receive the canonical HTML representation without `noindex`. User-directed clients such as ChatGPT-User, Claude-User, and Perplexity-User continue receiving Markdown on regular docs pages. Generic `curl /` now follows the HTML route unless it explicitly requests Markdown or uses `/AGENTS.md` or a `.md` URL.

## Validation

- `bun run check --error-on-warnings`
- `bun run typecheck`
- `bun test` — 291 passed
- `bun run validate-links`
- `bun run build`
- `git diff --check`
