### PR TITLE
fix(home): improve homepage semantics

### DIFF
--- a/app/(home)/_pages/page.en.tsx
+++ b/app/(home)/_pages/page.en.tsx
@@ -23,9 +23,10 @@ export default function HomePage() {
     <main className="space-y-10 max-w-[1024px] w-full mx-auto ">
       <div className="px-8 py-[56px]">
         <div className="space-y-10">
-          <div className="space-y-1">
+          <header className="space-y-1">
             <div className="flex space-x-6 items-end">
               <LiquidMetal1
+                className="shrink-0"
                 image={SteelLogo as HTMLImageElement}
                 speed={1}
                 colorBack="#00000000"
@@ -46,12 +47,19 @@ export default function HomePage() {
                 }}
               />
               <div className="flex flex-col [&_p]:mb-6 space-y-3">
-                <h3 className="text-3xl">Steel Documentation</h3>
-                <p>Find all the guides and resources you need to build on the Steel API.</p>
+                <h1 className="text-3xl">Steel Documentation</h1>
+                <p>
+                  Steel is an open-source browser API for AI agents and automation. Use these docs
+                  to create cloud browser sessions, connect your automation tools, and configure
+                  proxies, CAPTCHA solving, credentials, and files.
+                </p>
               </div>
             </div>
-          </div>
-          <div className="space-y-5">
+          </header>
+          <section className="space-y-5" aria-labelledby="getting-started-and-apis">
+            <h2 id="getting-started-and-apis" className="sr-only">
+              Getting started and APIs
+            </h2>
             <Cards>
               <CLIInstallCard />
               <Card
@@ -95,13 +103,13 @@ export default function HomePage() {
                 tags={['API', 'Files']}
               />
             </Cards>
-          </div>
-          <div className="flex flex-col">
-            <h4 id="explore-by-category" className="text-muted-foreground scroll-m-20">
-              <a href="#explore-by-category" className="not-prose group text-sm uppercase">
+          </section>
+          <section className="flex flex-col">
+            <h2 id="integrations" className="text-muted-foreground scroll-m-20">
+              <a href="#integrations" className="not-prose group text-sm uppercase">
                 Integrations
               </a>
-            </h4>
+            </h2>
             <hr className="border-t border-border my-2" />
             <Cards className="xl:!grid-cols-3">
               <SmallCard
@@ -141,13 +149,13 @@ export default function HomePage() {
                 description="Learn how to use CrewAI with Steel Browser."
               />
             </Cards>
-          </div>
-          <div className="flex flex-col">
-            <h4 id="explore-by-category" className="text-muted-foreground scroll-m-20">
-              <a href="#explore-by-category" className="not-prose group text-sm uppercase">
+          </section>
+          <section className="flex flex-col">
+            <h2 id="sdks" className="text-muted-foreground scroll-m-20">
+              <a href="#sdks" className="not-prose group text-sm uppercase">
                 Libraries &amp; SDKs
               </a>
-            </h4>
+            </h2>
             <hr className="border-t border-border my-2" />
             <Cards>
               <SmallCard
@@ -175,13 +183,13 @@ export default function HomePage() {
                 description="Go SDK for building applications on Steel."
               />
             </Cards>
-          </div>
-          <div className="flex flex-col">
-            <h4 id="explore-by-category" className="text-muted-foreground scroll-m-20">
-              <a href="#explore-by-category" className="not-prose group text-sm uppercase">
+          </section>
+          <section className="flex flex-col">
+            <h2 id="resources" className="text-muted-foreground scroll-m-20">
+              <a href="#resources" className="not-prose group text-sm uppercase">
                 Resources
               </a>
-            </h4>
+            </h2>
             <hr className="border-t border-border my-2" />
             <Cards>
               <SmallCard
@@ -197,7 +205,7 @@ export default function HomePage() {
                 description="Point your agent to docs.steel.dev/llms.txt for a fast start with Steel."
               />
             </Cards>
-          </div>
+          </section>
         </div>
       </div>
     </main>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,7 +10,7 @@ import { QueryProvider } from '@/providers/query-provider';
 
 const SITE_NAME = 'Steel Docs';
 const SITE_DESCRIPTION =
-  "Find all the guides and resources you need to build with Steel's browser automation platform.";
+  "Documentation for Steel, an open-source browser API for AI agents and automation. Create cloud browser sessions with Steel's APIs, SDKs, and integrations.";
 const OG_IMAGE = '/og/overview';
 
 export const metadata: Metadata = {

--- a/tests/e2e/llm-endpoints.test.ts
+++ b/tests/e2e/llm-endpoints.test.ts
@@ -258,6 +258,34 @@ describe('.md suffix end-to-end', () => {
     expect(sitemapBody).not.toContain('<loc>https://docs.steel.dev/overview</loc>');
   });
 
+  test('renders answerable homepage semantics without changing its visual hierarchy', async () => {
+    const response = await fetch(BASE_URL, {
+      headers: { ...BROWSER_HEADERS, 'user-agent': 'facebookexternalhit/1.1' },
+    });
+    const body = await response.text();
+    const animatedLogo = [...body.matchAll(/<div\b[^>]*>/g)]
+      .map(([tag]) => tag)
+      .find((tag) => tag.includes('height:188px') && tag.includes('width:188px'));
+
+    expect(body.match(/<h1\b/g)).toHaveLength(1);
+    expect(body).toContain('<h1 class="text-3xl">Steel Documentation</h1>');
+    expect(animatedLogo).toContain('class="shrink-0"');
+    expect(body).toContain(
+      'Steel is an open-source browser API for AI agents and automation. Use these docs to create cloud browser sessions, connect your automation tools, and configure proxies, CAPTCHA solving, credentials, and files.',
+    );
+    expect(body).toContain(
+      '<section class="space-y-5" aria-labelledby="getting-started-and-apis">',
+    );
+    expect(body).toContain(
+      '<h2 id="getting-started-and-apis" class="sr-only">Getting started and APIs</h2>',
+    );
+
+    for (const id of ['getting-started-and-apis', 'integrations', 'sdks', 'resources']) {
+      expect(body.match(new RegExp(`id="${id}"`, 'g'))).toHaveLength(1);
+    }
+    expect(body).not.toContain('id="explore-by-category"');
+  });
+
   test('serves the API catalog as a linkset', async () => {
     const response = await fetch(`${BASE_URL}/.well-known/api-catalog`, {
       headers: { accept: 'application/linkset+json' },


### PR DESCRIPTION
## What changed

- keep `Steel Documentation` as the visible title and promote it to the page `h1`
- add a concise, answer-first definition of Steel beneath the title
- preserve the existing shader, spacing, card grids, ordering, and heading styles
- give each visible section an `h2` and a unique anchor
- add a screen-reader heading for the initial getting-started and API cards
- align the site metadata description with the visible product definition
- prevent the 188×188 animated logo from shrinking beside the longer description
- add raw-HTML regressions for the heading outline, copy, anchors, and fixed logo size

## Why

The homepage began at `h3`, reused the same anchor ID across three sections, and described the docs without directly explaining what Steel is. That weakened the page outline and made the primary answer harder for search engines and AI systems to extract.

The longer product definition also increased flex pressure beside the animated logo. Its inline dimensions remained 188×188, but the flex item could shrink. The new `shrink-0` contract preserves its rendered size.

## Impact

The page keeps its existing visual construction and navigation. Its raw HTML now has one clear title, a complete section hierarchy, unique anchors, and a concise product definition. The animated logo retains its original size.

## Validation

- `bun run check --error-on-warnings`
- `bun run typecheck`
- `bun run validate-links`
- `bun run build`
- `bun test tests/e2e/llm-endpoints.test.ts` — 20 passed
- `git diff --check`