### PR TITLE
feat(seo): complete structured data entity graph

### DIFF
--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from 'next';
+import { WebPageJsonLd } from '@/components/page-jsonld';
+import { DOCS_SITE_DESCRIPTION } from '@/lib/structured-data';
 import EnglishPage from './_pages/page.en';
 
 export const metadata: Metadata = {
@@ -11,5 +13,10 @@ export const metadata: Metadata = {
 };
 
 export default function HomePage() {
-  return <EnglishPage />;
+  return (
+    <>
+      <WebPageJsonLd title="Steel Documentation" description={DOCS_SITE_DESCRIPTION} path="/" />
+      <EnglishPage />
+    </>
+  );
 }

--- a/app/[...slug]/page.tsx
+++ b/app/[...slug]/page.tsx
@@ -23,11 +23,11 @@ import { LLMShare } from '@/components/llm-share';
 import { getMDXComponents } from '@/components/mdx';
 import { Mermaid } from '@/components/mdx/mermaid';
 import { APIPage } from '@/components/openapi/api-page';
-import { BreadcrumbJsonLd, TechArticleJsonLd } from '@/components/page-jsonld';
+import { BreadcrumbJsonLd, TechArticleJsonLd, WebPageJsonLd } from '@/components/page-jsonld';
 import { Badge } from '@/components/ui/badge';
 import * as customIcons from '@/components/ui/icon';
 import { TagFilterSystem } from '@/components/ui/tag-filter-system';
-import { getLastModified } from '@/lib/last-modified';
+import { getGitLastModified } from '@/lib/last-modified';
 import { getAllFilterablePages, source } from '@/lib/source';
 import type { HeadingProps } from '@/types';
 
@@ -140,8 +140,9 @@ export default async function Page(props: {
   // TechArticle JSON-LD on integration pages; cookbook recipes emit their own
   // via RecipeJsonLd. The hub page at /integrations is a listing, not an article.
   const isIntegrationArticle = /^\/integrations\/.+/.test(canonicalPath);
+  const isAuthorProfile = /^\/cookbook\/authors\/.+/.test(canonicalPath);
   const lastModified = isIntegrationArticle
-    ? await getLastModified(page.data._file?.absolutePath)
+    ? getGitLastModified(page.data._file?.absolutePath)
     : undefined;
 
   // Prepare page data for context - only include serializable data
@@ -158,6 +159,13 @@ export default async function Page(props: {
   return (
     <DocsPage data={pageData}>
       <BreadcrumbJsonLd items={breadcrumbItems} />
+      {!isAuthorProfile && (
+        <WebPageJsonLd
+          title={page.data.title}
+          description={page.data.description}
+          path={canonicalPath}
+        />
+      )}
       {isIntegrationArticle && (
         <TechArticleJsonLd
           title={page.data.title}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,23 +4,22 @@ import { RootProvider } from 'fumadocs-ui/provider';
 import { GeistMono } from 'geist/font/mono';
 import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
+import { SiteIdentityJsonLd } from '@/components/page-jsonld';
 import { inter, jetBrainsMono } from '@/fonts';
 import { KeyboardShortcutsProvider } from '@/hooks/use-keyboard-shortcuts';
+import { DOCS_SITE_DESCRIPTION, DOCS_SITE_NAME } from '@/lib/structured-data';
 import { QueryProvider } from '@/providers/query-provider';
 
-const SITE_NAME = 'Steel Docs';
-const SITE_DESCRIPTION =
-  "Documentation for Steel, an open-source browser API for AI agents and automation. Create cloud browser sessions with Steel's APIs, SDKs, and integrations.";
 const OG_IMAGE = '/og/overview';
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://docs.steel.dev'),
-  applicationName: SITE_NAME,
+  applicationName: DOCS_SITE_NAME,
   title: {
-    template: `%s | ${SITE_NAME}`,
-    default: SITE_NAME,
+    template: `%s | ${DOCS_SITE_NAME}`,
+    default: DOCS_SITE_NAME,
   },
-  description: SITE_DESCRIPTION,
+  description: DOCS_SITE_DESCRIPTION,
   alternates: {
     types: {
       'text/plain': '/llms.txt',
@@ -28,18 +27,18 @@ export const metadata: Metadata = {
   },
   openGraph: {
     type: 'website',
-    siteName: SITE_NAME,
+    siteName: DOCS_SITE_NAME,
     locale: 'en_US',
-    title: SITE_NAME,
-    description: SITE_DESCRIPTION,
-    images: [{ url: OG_IMAGE, width: 1200, height: 630, alt: SITE_NAME }],
+    title: DOCS_SITE_NAME,
+    description: DOCS_SITE_DESCRIPTION,
+    images: [{ url: OG_IMAGE, width: 1200, height: 630, alt: DOCS_SITE_NAME }],
   },
   twitter: {
     card: 'summary_large_image',
-    site: '@steelsystems',
-    creator: '@steelsystems',
-    title: SITE_NAME,
-    description: SITE_DESCRIPTION,
+    site: '@steeldotdev',
+    creator: '@steeldotdev',
+    title: DOCS_SITE_NAME,
+    description: DOCS_SITE_DESCRIPTION,
     images: [OG_IMAGE],
   },
 };
@@ -51,7 +50,9 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       className={`dark ${inter.variable} ${jetBrainsMono.variable} ${GeistMono.variable}`}
       suppressHydrationWarning
     >
-      <head />
+      <head>
+        <SiteIdentityJsonLd />
+      </head>
       <body className="flex flex-col min-h-screen">
         {process.env.NEXT_PUBLIC_GTM_ID && (
           <GoogleTagManager gtmId={process.env.NEXT_PUBLIC_GTM_ID} />

--- a/components/page-jsonld.tsx
+++ b/components/page-jsonld.tsx
@@ -1,10 +1,35 @@
-// ABOUTME: BreadcrumbList and TechArticle JSON-LD emitted by the docs page renderer.
-// ABOUTME: BreadcrumbJsonLd runs site-wide; TechArticleJsonLd covers integration pages.
-const SITE_URL = 'https://docs.steel.dev';
+// ABOUTME: Site identity, page, breadcrumb, and article JSON-LD renderers.
+// ABOUTME: Shared builders keep entity IDs consistent across documentation pages.
+import {
+  buildSiteIdentitySchema,
+  buildTechArticleSchema,
+  buildWebPageSchema,
+  DOCS_URL,
+} from '@/lib/structured-data';
 
 interface CrumbItem {
   name: string;
   url: string;
+}
+
+function JsonLd({ data }: { data: Record<string, unknown> }) {
+  return (
+    <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }} />
+  );
+}
+
+export function SiteIdentityJsonLd() {
+  return <JsonLd data={buildSiteIdentitySchema()} />;
+}
+
+interface WebPageProps {
+  title: string;
+  description?: string;
+  path: string;
+}
+
+export function WebPageJsonLd({ title, description, path }: WebPageProps) {
+  return <JsonLd data={buildWebPageSchema({ name: title, description, path })} />;
 }
 
 // BreadcrumbList JSON-LD: home + named ancestors that have their own page +
@@ -19,12 +44,10 @@ export function BreadcrumbJsonLd({ items }: { items: CrumbItem[] }) {
       '@type': 'ListItem',
       position: index + 1,
       name: item.name,
-      item: `${SITE_URL}${item.url}`,
+      item: `${DOCS_URL}${item.url}`,
     })),
   };
-  return (
-    <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }} />
-  );
+  return <JsonLd data={data} />;
 }
 
 interface TechArticleProps {
@@ -45,19 +68,15 @@ export function TechArticleJsonLd({
   datePublished,
   dateModified,
 }: TechArticleProps) {
-  const url = `${SITE_URL}${path}`;
-  const data: Record<string, unknown> = {
-    '@context': 'https://schema.org',
-    '@type': 'TechArticle',
-    headline: title,
-    url,
-    mainEntityOfPage: { '@type': 'WebPage', '@id': url },
-    author: { '@type': 'Organization', name: 'Steel', url: 'https://steel.dev' },
-  };
-  if (description) data.description = description;
-  if (datePublished) data.datePublished = datePublished;
-  if (dateModified) data.dateModified = dateModified;
   return (
-    <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }} />
+    <JsonLd
+      data={buildTechArticleSchema({
+        name: title,
+        description,
+        path,
+        datePublished,
+        dateModified,
+      })}
+    />
   );
 }

--- a/components/recipe-jsonld.tsx
+++ b/components/recipe-jsonld.tsx
@@ -1,4 +1,4 @@
-const SITE_URL = 'https://docs.steel.dev';
+import { DOCS_URL, getWebPageId, STEEL_ORGANIZATION_ID } from '@/lib/structured-data';
 
 interface AuthorRef {
   handle: string;
@@ -29,19 +29,21 @@ export function RecipeJsonLd({
   dateModified,
   sourceUrl,
 }: Props) {
-  const recipeUrl = `${SITE_URL}/cookbook/${slug}`;
+  const recipePath = `/cookbook/${slug}`;
+  const recipeUrl = `${DOCS_URL}${recipePath}`;
   const data: Record<string, unknown> = {
     '@context': 'https://schema.org',
     '@type': 'TechArticle',
     headline: title,
     description,
     url: recipeUrl,
-    mainEntityOfPage: { '@type': 'WebPage', '@id': recipeUrl },
+    mainEntityOfPage: { '@id': getWebPageId(recipePath) },
     author: authors.map((a) => ({
       '@type': 'Person',
       name: a.name,
-      url: `${SITE_URL}/cookbook/authors/${a.handle}`,
+      url: `${DOCS_URL}/cookbook/authors/${a.handle}`,
     })),
+    publisher: { '@id': STEEL_ORGANIZATION_ID },
   };
   if (datePublished) data.datePublished = datePublished;
   if (dateModified) data.dateModified = dateModified;

--- a/lib/last-modified.ts
+++ b/lib/last-modified.ts
@@ -1,12 +1,14 @@
-// ABOUTME: Resolves a content file's last-modified date from git history,
-// ABOUTME: falling back to filesystem mtime. Shared by the sitemap and JSON-LD.
+// ABOUTME: Resolves content freshness from Git, with a separate filesystem fallback.
+// ABOUTME: Schema uses Git-only dates; sitemap discovery may fall back to file mtime.
 import { execSync } from 'node:child_process';
 import { stat } from 'node:fs/promises';
 
-function gitLastModified(absPath: string): Date | undefined {
+export function getGitLastModified(absPath: string | undefined): Date | undefined {
+  if (!absPath) return undefined;
   try {
     const out = execSync(`git log -1 --format=%aI -- "${absPath}"`, {
       encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
       timeout: 5000,
     }).trim();
     if (!out) return undefined;
@@ -27,5 +29,5 @@ async function fsLastModified(absPath: string): Promise<Date | undefined> {
 
 export async function getLastModified(absPath: string | undefined): Promise<Date | undefined> {
   if (!absPath) return undefined;
-  return gitLastModified(absPath) ?? (await fsLastModified(absPath));
+  return getGitLastModified(absPath) ?? (await fsLastModified(absPath));
 }

--- a/lib/structured-data.ts
+++ b/lib/structured-data.ts
@@ -1,0 +1,89 @@
+// ABOUTME: Shared schema.org entity IDs and pure builders for Steel documentation pages.
+// ABOUTME: Keeps site identity and page references consistent across JSON-LD renderers.
+export const DOCS_URL = 'https://docs.steel.dev';
+export const STEEL_URL = 'https://steel.dev/';
+export const STEEL_ORGANIZATION_ID = `${DOCS_URL}/#organization`;
+export const DOCS_WEBSITE_ID = `${DOCS_URL}/#website`;
+export const DOCS_SITE_NAME = 'Steel Docs';
+export const DOCS_SITE_DESCRIPTION =
+  "Documentation for Steel, an open-source browser API for AI agents and automation. Create cloud browser sessions with Steel's APIs, SDKs, and integrations.";
+export const STEEL_SAME_AS = ['https://github.com/steel-dev', 'https://x.com/steeldotdev'] as const;
+
+interface WebPageSchemaOptions {
+  name: string;
+  description?: string;
+  path: string;
+}
+
+interface TechArticleSchemaOptions extends WebPageSchemaOptions {
+  datePublished?: string;
+  dateModified?: string;
+}
+
+export function getCanonicalPageUrl(path: string): string {
+  return path === '/' ? `${DOCS_URL}/` : `${DOCS_URL}${path}`;
+}
+
+export function getWebPageId(path: string): string {
+  return `${getCanonicalPageUrl(path)}#webpage`;
+}
+
+export function buildSiteIdentitySchema() {
+  return {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'Organization',
+        '@id': STEEL_ORGANIZATION_ID,
+        name: 'Steel',
+        url: STEEL_URL,
+        sameAs: STEEL_SAME_AS,
+      },
+      {
+        '@type': 'WebSite',
+        '@id': DOCS_WEBSITE_ID,
+        url: `${DOCS_URL}/`,
+        name: DOCS_SITE_NAME,
+        description: DOCS_SITE_DESCRIPTION,
+        publisher: { '@id': STEEL_ORGANIZATION_ID },
+      },
+    ],
+  };
+}
+
+export function buildWebPageSchema({ name, description, path }: WebPageSchemaOptions) {
+  const data: Record<string, unknown> = {
+    '@context': 'https://schema.org',
+    '@type': 'WebPage',
+    '@id': getWebPageId(path),
+    url: getCanonicalPageUrl(path),
+    name,
+    isPartOf: { '@id': DOCS_WEBSITE_ID },
+    about: { '@id': STEEL_ORGANIZATION_ID },
+    publisher: { '@id': STEEL_ORGANIZATION_ID },
+  };
+  if (description) data.description = description;
+  return data;
+}
+
+export function buildTechArticleSchema({
+  name,
+  description,
+  path,
+  datePublished,
+  dateModified,
+}: TechArticleSchemaOptions) {
+  const data: Record<string, unknown> = {
+    '@context': 'https://schema.org',
+    '@type': 'TechArticle',
+    headline: name,
+    url: getCanonicalPageUrl(path),
+    mainEntityOfPage: { '@id': getWebPageId(path) },
+    author: { '@id': STEEL_ORGANIZATION_ID },
+    publisher: { '@id': STEEL_ORGANIZATION_ID },
+  };
+  if (description) data.description = description;
+  if (datePublished) data.datePublished = datePublished;
+  if (dateModified) data.dateModified = dateModified;
+  return data;
+}

--- a/tests/e2e/llm-endpoints.test.ts
+++ b/tests/e2e/llm-endpoints.test.ts
@@ -47,6 +47,18 @@ function hasActiveNavLink(body: string, href: string): boolean {
   );
 }
 
+function getJsonLdNodes(body: string): Array<Record<string, unknown>> {
+  const scripts = [...body.matchAll(/<script\b([^>]*)>([\s\S]*?)<\/script>/g)]
+    .filter(([, attributes]) => /type="application\/ld\+json"/.test(attributes))
+    .map(([, , contents]) => JSON.parse(contents) as Record<string, unknown>);
+
+  return scripts.flatMap((script) =>
+    Array.isArray(script['@graph'])
+      ? (script['@graph'] as Array<Record<string, unknown>>)
+      : [script],
+  );
+}
+
 async function waitForServer(): Promise<void> {
   const deadline = Date.now() + 90000;
   while (Date.now() < deadline) {
@@ -284,6 +296,94 @@ describe('.md suffix end-to-end', () => {
       expect(body.match(new RegExp(`id="${id}"`, 'g'))).toHaveLength(1);
     }
     expect(body).not.toContain('id="explore-by-category"');
+  });
+
+  test('publishes a connected, page-aware structured data graph', async () => {
+    const rootResponse = await fetch(BASE_URL, {
+      headers: { ...BROWSER_HEADERS, 'user-agent': 'facebookexternalhit/1.1' },
+    });
+    const rootBody = await rootResponse.text();
+    const rootNodes = getJsonLdNodes(rootBody);
+    const organization = rootNodes.find((node) => node['@type'] === 'Organization');
+    const website = rootNodes.find((node) => node['@type'] === 'WebSite');
+    const homepage = rootNodes.find((node) => node['@type'] === 'WebPage');
+
+    expect(organization).toMatchObject({
+      '@id': 'https://docs.steel.dev/#organization',
+      name: 'Steel',
+      url: 'https://steel.dev/',
+      sameAs: ['https://github.com/steel-dev', 'https://x.com/steeldotdev'],
+    });
+    expect(website).toMatchObject({
+      '@id': 'https://docs.steel.dev/#website',
+      publisher: { '@id': 'https://docs.steel.dev/#organization' },
+    });
+    expect(homepage).toMatchObject({
+      '@id': 'https://docs.steel.dev/#webpage',
+      url: 'https://docs.steel.dev/',
+      name: 'Steel Documentation',
+      isPartOf: { '@id': 'https://docs.steel.dev/#website' },
+      about: { '@id': 'https://docs.steel.dev/#organization' },
+      publisher: { '@id': 'https://docs.steel.dev/#organization' },
+    });
+    expect(homepage).not.toHaveProperty('datePublished');
+    expect(homepage).not.toHaveProperty('dateModified');
+    expect(rootBody).toContain('<meta name="twitter:site" content="@steeldotdev"/>');
+    expect(rootBody).toContain('<meta name="twitter:creator" content="@steeldotdev"/>');
+
+    const ordinaryBody = await (
+      await fetch(`${BASE_URL}/overview/sessions-api/quickstart`, {
+        headers: BROWSER_HEADERS,
+      })
+    ).text();
+    const ordinaryNodes = getJsonLdNodes(ordinaryBody);
+    expect(
+      ordinaryNodes.find(
+        (node) => node['@id'] === 'https://docs.steel.dev/overview/sessions-api/quickstart#webpage',
+      ),
+    ).toMatchObject({ '@type': 'WebPage', name: 'Quickstart' });
+    expect(ordinaryNodes.some((node) => node['@type'] === 'BreadcrumbList')).toBe(true);
+    expect(ordinaryNodes.some((node) => node['@type'] === 'TechArticle')).toBe(false);
+
+    const integrationBody = await (
+      await fetch(`${BASE_URL}/integrations/playwright`, { headers: BROWSER_HEADERS })
+    ).text();
+    const integrationNodes = getJsonLdNodes(integrationBody);
+    const integrationPage = integrationNodes.find(
+      (node) => node['@id'] === 'https://docs.steel.dev/integrations/playwright#webpage',
+    );
+    const integrationArticle = integrationNodes.find((node) => node['@type'] === 'TechArticle');
+    expect(integrationPage).toMatchObject({ '@type': 'WebPage' });
+    expect(integrationArticle).toMatchObject({
+      mainEntityOfPage: {
+        '@id': 'https://docs.steel.dev/integrations/playwright#webpage',
+      },
+      author: { '@id': 'https://docs.steel.dev/#organization' },
+      publisher: { '@id': 'https://docs.steel.dev/#organization' },
+    });
+    if (integrationArticle?.dateModified) {
+      expect(integrationArticle.dateModified).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    }
+
+    const recipeBody = await (
+      await fetch(`${BASE_URL}/cookbook/playwright`, { headers: BROWSER_HEADERS })
+    ).text();
+    const recipeNodes = getJsonLdNodes(recipeBody);
+    const recipeArticle = recipeNodes.find((node) => node['@type'] === 'TechArticle');
+    expect(recipeArticle).toMatchObject({
+      mainEntityOfPage: {
+        '@id': 'https://docs.steel.dev/cookbook/playwright#webpage',
+      },
+      publisher: { '@id': 'https://docs.steel.dev/#organization' },
+    });
+    expect(recipeArticle?.author).toBeArray();
+
+    const authorBody = await (
+      await fetch(`${BASE_URL}/cookbook/authors/hussufo`, { headers: BROWSER_HEADERS })
+    ).text();
+    const authorNodes = getJsonLdNodes(authorBody);
+    expect(authorNodes.some((node) => node['@type'] === 'ProfilePage')).toBe(true);
+    expect(authorNodes.some((node) => node['@type'] === 'WebPage')).toBe(false);
   });
 
   test('serves the API catalog as a linkset', async () => {

--- a/tests/last-modified.test.ts
+++ b/tests/last-modified.test.ts
@@ -1,0 +1,21 @@
+// ABOUTME: Verifies schema freshness stays Git-derived while sitemap dates may use mtime.
+// ABOUTME: Protects JSON-LD from presenting checkout or build timestamps as content edits.
+import { expect, test } from 'bun:test';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { getGitLastModified, getLastModified } from '@/lib/last-modified';
+
+test('keeps filesystem fallback out of Git-derived schema freshness', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'steel-schema-freshness-'));
+  const file = join(directory, 'untracked.mdx');
+
+  try {
+    await writeFile(file, '# Untracked\n');
+
+    expect(getGitLastModified(file)).toBeUndefined();
+    expect(await getLastModified(file)).toBeInstanceOf(Date);
+  } finally {
+    await rm(directory, { recursive: true });
+  }
+});

--- a/tests/structured-data.test.ts
+++ b/tests/structured-data.test.ts
@@ -1,0 +1,83 @@
+// ABOUTME: Contract tests for shared schema.org entity IDs and pure JSON-LD builders.
+// ABOUTME: Prevents disconnected entities, unverified profiles, and invented freshness.
+import { describe, expect, test } from 'bun:test';
+import {
+  buildSiteIdentitySchema,
+  buildTechArticleSchema,
+  buildWebPageSchema,
+  DOCS_WEBSITE_ID,
+  getWebPageId,
+  STEEL_ORGANIZATION_ID,
+  STEEL_SAME_AS,
+} from '@/lib/structured-data';
+
+describe('structured data builders', () => {
+  test('builds one connected site identity graph with verified profiles', () => {
+    const schema = buildSiteIdentitySchema();
+    const organization = schema['@graph'].find((node) => node['@type'] === 'Organization');
+    const website = schema['@graph'].find((node) => node['@type'] === 'WebSite');
+
+    expect(organization).toEqual({
+      '@type': 'Organization',
+      '@id': STEEL_ORGANIZATION_ID,
+      name: 'Steel',
+      url: 'https://steel.dev/',
+      sameAs: STEEL_SAME_AS,
+    });
+    expect(website).toMatchObject({
+      '@id': DOCS_WEBSITE_ID,
+      url: 'https://docs.steel.dev/',
+      name: 'Steel Docs',
+      publisher: { '@id': STEEL_ORGANIZATION_ID },
+    });
+    expect(STEEL_SAME_AS).toEqual(['https://github.com/steel-dev', 'https://x.com/steeldotdev']);
+  });
+
+  test('builds the homepage entity without invented freshness', () => {
+    const page = buildWebPageSchema({
+      name: 'Steel Documentation',
+      description: 'Documentation for Steel.',
+      path: '/',
+    });
+
+    expect(page).toMatchObject({
+      '@type': 'WebPage',
+      '@id': 'https://docs.steel.dev/#webpage',
+      url: 'https://docs.steel.dev/',
+      name: 'Steel Documentation',
+      isPartOf: { '@id': DOCS_WEBSITE_ID },
+      about: { '@id': STEEL_ORGANIZATION_ID },
+      publisher: { '@id': STEEL_ORGANIZATION_ID },
+    });
+    expect(page).not.toHaveProperty('datePublished');
+    expect(page).not.toHaveProperty('dateModified');
+  });
+
+  test('uses canonical page IDs and omits absent optional fields', () => {
+    const page = buildWebPageSchema({
+      name: 'Quickstart',
+      path: '/overview/sessions-api/quickstart',
+    });
+
+    expect(page['@id']).toBe('https://docs.steel.dev/overview/sessions-api/quickstart#webpage');
+    expect(page).not.toHaveProperty('description');
+  });
+
+  test('connects articles to the emitted page and organization entities', () => {
+    const article = buildTechArticleSchema({
+      name: 'Run Playwright on Steel Cloud Browsers',
+      description: 'Connect Playwright to Steel.',
+      path: '/integrations/playwright',
+      dateModified: '2026-07-30',
+    });
+
+    expect(article).toMatchObject({
+      '@type': 'TechArticle',
+      mainEntityOfPage: { '@id': getWebPageId('/integrations/playwright') },
+      author: { '@id': STEEL_ORGANIZATION_ID },
+      publisher: { '@id': STEEL_ORGANIZATION_ID },
+      dateModified: '2026-07-30',
+    });
+    expect(article).not.toHaveProperty('datePublished');
+  });
+});


### PR DESCRIPTION
## What changed

- add stable `Organization`, `WebSite`, and page-level `WebPage` JSON-LD entities
- connect integration and cookbook `TechArticle` schema to shared page and publisher IDs
- keep cookbook author profiles specialized without a duplicate generic page entity
- use Git-only modification dates for article freshness while preserving sitemap filesystem fallback
- update the Steel Twitter metadata to `@steeldotdev`
- add unit and rendered-HTML regression coverage across homepage, docs, integrations, recipes, and author profiles

## Why

The docs already emitted breadcrumbs and several specialized schema types, but they were disconnected: the homepage had no site identity graph, ordinary docs had no page entity, and article references pointed at page entities that were not emitted. This completes a coherent graph without changing visible page construction or inventing freshness dates.

`/changelog` remains unchanged because it is a redirect to the latest entry, not a standalone listing page.

## Validation

- `bun test` — 296 passed
- `bun run check --error-on-warnings`
- `bun run typecheck`
- `bun run validate-links`
- `bun run build`
- `git diff --check`