### PR TITLE
fix(api): advertise the API catalog relation

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -273,7 +273,7 @@ const config = {
         headers: [
           {
             key: "Link",
-            value: '</llms.txt>; rel="alternate"; type="text/markdown", </llms-full.txt>; rel="alternate"; type="text/markdown"',
+            value: '</llms.txt>; rel="alternate"; type="text/markdown", </llms-full.txt>; rel="alternate"; type="text/markdown", </.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"',
           },
         ],
       },

--- a/public/.well-known/api-catalog
+++ b/public/.well-known/api-catalog
@@ -13,7 +13,7 @@
       "service-desc": [
         {
           "href": "https://api.steel.dev/sdk-openapi.json",
-          "type": "application/openapi+json"
+          "type": "application/json"
         }
       ],
       "service-doc": [

--- a/tests/api-catalog.test.ts
+++ b/tests/api-catalog.test.ts
@@ -44,7 +44,7 @@ describe('api catalog document', () => {
     // Pointing at the spec the API itself serves keeps one canonical copy, so
     // the catalog cannot advertise a spec that has drifted from the live API.
     expect(desc?.href).toBe('https://api.steel.dev/sdk-openapi.json');
-    expect(desc?.type).toBe('application/openapi+json');
+    expect(desc?.type).toBe('application/json');
   });
 
   test('links human documentation for the API', () => {

--- a/tests/e2e/llm-endpoints.test.ts
+++ b/tests/e2e/llm-endpoints.test.ts
@@ -41,6 +41,24 @@ function varyTokens(response: Response): string[] {
     .filter(Boolean);
 }
 
+function hasLinkRelation(response: Response, target: string, relation: string): boolean {
+  return (response.headers.get('Link') ?? '')
+    .split(',')
+    .map((value) => value.trim())
+    .some((value) => {
+      const [rawTarget, ...rawParameters] = value.split(';');
+      if (rawTarget.trim() !== `<${target}>`) return false;
+
+      const relationParameter = rawParameters
+        .map((parameter) => parameter.trim())
+        .find((parameter) => parameter.toLowerCase().startsWith('rel='));
+      if (!relationParameter) return false;
+
+      const relations = relationParameter.slice('rel='.length).replace(/^"|"$/g, '').split(/\s+/);
+      return relations.includes(relation);
+    });
+}
+
 function hasActiveNavLink(body: string, href: string): boolean {
   return [...body.matchAll(/<a\b[^>]*>/g)].some(
     ([tag]) => tag.includes(`href="${href}"`) && tag.includes('data-nav-active="true"'),
@@ -396,6 +414,17 @@ describe('.md suffix end-to-end', () => {
     expect(catalog.linkset.length).toBeGreaterThan(0);
   });
 
+  test('advertises the API catalog relation on HEAD', async () => {
+    const response = await fetch(`${BASE_URL}/.well-known/api-catalog`, {
+      method: 'HEAD',
+      redirect: 'manual',
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toStartWith('application/linkset+json');
+    expect(hasLinkRelation(response, '/.well-known/api-catalog', 'api-catalog')).toBe(true);
+  });
+
   test('serves the API catalog to markdown clients too, without rewriting it', async () => {
     const response = await fetch(`${BASE_URL}/.well-known/api-catalog`, {
       headers: { accept: 'text/markdown', 'user-agent': 'claude-code/1.0' },
@@ -423,5 +452,8 @@ describe('.md suffix end-to-end', () => {
     });
     expect(response.status).toBe(200);
     expect(response.headers.get('content-type')).toStartWith('text/html');
+    expect(hasLinkRelation(response, '/.well-known/api-catalog', 'api-catalog')).toBe(true);
+    expect(hasLinkRelation(response, '/llms.txt', 'alternate')).toBe(true);
+    expect(hasLinkRelation(response, '/llms-full.txt', 'alternate')).toBe(true);
   });
 });


### PR DESCRIPTION
## What changed

- advertise `/.well-known/api-catalog` through the global HTTP `Link` header with `rel="api-catalog"`
- preserve the existing `llms.txt` and `llms-full.txt` alternate relations
- change the catalog service-description hint from `application/openapi+json` to the media type the canonical API endpoint actually serves: `application/json`
- add runtime regressions for RFC 9727 HEAD discovery and normal-page advertisement

## Why

The JSON Linkset existed and had the correct response content type, but its HTTP discovery contract was incomplete. A HEAD request did not advertise the required `api-catalog` relation, and the catalog described a different OpenAPI media type than the canonical API endpoint returns.

Live verification on 2026-07-30 confirmed `https://api.steel.dev/sdk-openapi.json` returns HTTP 200 with `Content-Type: application/json; charset=utf-8`.

## Impact

Agents and API tooling can discover the catalog from both the well-known endpoint and regular docs responses without losing the existing Markdown alternates.

## Validation

- `bun test` — 297 passed
- `bun run typecheck`
- `bun run check --error-on-warnings`
- `bun run validate-links`
- `bun run build`
- `git diff --check`