### PR TITLE
fix(robots): test shared user-agent groups

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -50,4 +50,3 @@ Content-Signal: search=yes, ai-input=yes, ai-train=yes
 Allow: /
 
 Sitemap: https://docs.steel.dev/sitemap.xml
-Host: docs.steel.dev

--- a/tests/robots-txt.test.ts
+++ b/tests/robots-txt.test.ts
@@ -12,7 +12,8 @@ const ROBOTS = readFileSync(
 /** Splits robots.txt into its User-agent groups, keyed by agent name. */
 function parseGroups(source: string): Map<string, string[]> {
   const groups = new Map<string, string[]>();
-  let current: string[] | null = null;
+  let activeAgents: string[] = [];
+  let groupHasDirectives = false;
 
   for (const line of source.split('\n')) {
     const trimmed = line.trim();
@@ -23,15 +24,34 @@ function parseGroups(source: string): Map<string, string[]> {
     const value = rawValue.join(':').trim();
 
     if (key === 'user-agent') {
-      current = [];
-      groups.set(value, current);
-    } else if (current) {
-      current.push(trimmed);
+      activeAgents = groupHasDirectives ? [value] : [...activeAgents, value];
+      groupHasDirectives = false;
+      if (!groups.has(value)) groups.set(value, []);
+    } else if (activeAgents.length > 0) {
+      groupHasDirectives = true;
+      for (const agent of activeAgents) {
+        groups.get(agent)?.push(trimmed);
+      }
     }
   }
 
   return groups;
 }
+
+describe('parseGroups', () => {
+  const fixtureGroups = parseGroups(`User-agent: Agent-A
+User-agent: Agent-B
+Allow: /
+
+User-agent: Agent-A
+Disallow: /private
+`);
+
+  test('shares directives across stacked agents and combines repeated groups', () => {
+    expect(fixtureGroups.get('Agent-A')).toEqual(['Allow: /', 'Disallow: /private']);
+    expect(fixtureGroups.get('Agent-B')).toEqual(['Allow: /']);
+  });
+});
 
 const groups = parseGroups(ROBOTS);
 
@@ -70,10 +90,9 @@ describe('robots.txt content signals', () => {
     }
   });
 
-  test('keeps the crawl directives, sitemap and host', () => {
+  test('keeps the crawl directives and sitemap', () => {
     expect(groups.get('*')).toContain('Allow: /');
     expect(groups.get('ClaudeBot')).toContain('Allow: /');
     expect(ROBOTS).toContain('Sitemap: https://docs.steel.dev/sitemap.xml');
-    expect(ROBOTS).toContain('Host: docs.steel.dev');
   });
 });


### PR DESCRIPTION
## What changed

- make the test-local robots parser apply directives to consecutive `User-agent` records
- combine directives when the same agent appears in a later group
- add a characterization fixture covering stacked, repeated, and non-leaking group behavior
- remove the deprecated `Host: docs.steel.dev` record

## Why

The parser replaced its active directive array for every `User-agent` line. That meant stacked agents did not share following directives, and a repeated agent lost directives from its earlier group. The current robots policy happened not to use those forms, but the test helper could silently mis-evaluate a future compacted file.

## Impact

All ten crawler groups retain the same `Content-Signal` values and `Allow: /` policy. The sitemap remains unchanged; only the deprecated Host extension is removed.

## Validation

- `bun test` — 298 passed
- `bun run typecheck`
- `bun run check --error-on-warnings`
- `bun run validate-links`
- confirmed 10 `Content-Signal` and 10 `Allow: /` records
- confirmed no `Host:` record
- `git diff --check`