### PR TITLE
ci: bound the test workflow runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## What changed

Add `timeout-minutes: 30` to the existing CI job.

## Why

This bounds a stalled runner or runtime well below the six-hour GitHub Actions default. Recent successful jobs finish in roughly 2–10 minutes, so the ceiling leaves ample headroom.

## Scope

This is exactly one workflow line. No test command, timeout, `Bun.spawnSync` helper, retry, or output handling changed.

## Validation

- parsed `.github/workflows/ci.yml` and confirmed `jobs.lint.timeout-minutes` is numeric `30`
- `git diff --check`
- hosted CI is the final workflow validation before merge