### PR TITLE
fix(tests): bound e2e dev-server teardown so CI stops failing

### DIFF
--- a/tests/e2e/llm-endpoints.test.ts
+++ b/tests/e2e/llm-endpoints.test.ts
@@ -94,21 +94,46 @@ async function waitForServer(): Promise<void> {
   throw new Error(`Dev server did not become ready on port ${PORT}`);
 }
 
+function killProcessGroup(pid: number, signal: NodeJS.Signals): void {
+  try {
+    process.kill(-pid, signal);
+  } catch {
+    try {
+      process.kill(pid, signal);
+    } catch {}
+  }
+}
+
 describe('.md suffix end-to-end', () => {
   beforeAll(async () => {
     server = Bun.spawn(['bunx', 'next', 'dev', '--turbopack', '-p', String(PORT)], {
       cwd: PROJECT_ROOT,
       stdout: 'ignore',
       stderr: 'ignore',
+      // detached puts the dev server at the head of its own process group, so
+      // teardown can signal the whole tree (next-server, Turbopack workers),
+      // not just the direct bunx child.
+      detached: true,
     });
     await waitForServer();
   });
 
   afterAll(async () => {
-    // Wait for the process to fully exit so the dev server's CPU and port
-    // are released before later test files (Chromium renders) start.
-    server?.kill();
-    await server?.exited;
+    // Tear down the whole process group so the dev server's CPU and port are
+    // released before later test files (Chromium renders) start. The awaited
+    // exit is bounded and escalates to SIGKILL, so a child that ignores or
+    // defers SIGTERM can never hang the hook past its timeout.
+    const pid = server?.pid;
+    if (!pid) return;
+    killProcessGroup(pid, 'SIGTERM');
+    const stopped = await Promise.race([
+      server.exited.then(() => true),
+      Bun.sleep(3000).then(() => false),
+    ]);
+    if (!stopped) {
+      killProcessGroup(pid, 'SIGKILL');
+      await Promise.race([server.exited, Bun.sleep(2000)]);
+    }
   });
 
   test('serves markdown with the index pointer at a .md-suffixed docs URL', async () => {


### PR DESCRIPTION
## Why CI is red

Every run on `main` since PR #97 fails on a **single test hook**:

```
(fail) .md suffix end-to-end > (unnamed) [120007ms]
  ^ a beforeEach/afterEach hook timed out for this test.
298 pass, 1 fail
```

The failing file is `tests/e2e/llm-endpoints.test.ts`. It boots a Next dev server in `beforeAll` and tears it down in `afterAll`:

```ts
afterAll(async () => {
  server?.kill();          // SIGTERM → only the direct bunx child
  await server?.exited;    // ← hangs here
});
```

- All ~24 named tests pass, so `beforeAll` succeeded — the server came up.
- The `(unnamed)` failure is Bun's report of the **`afterAll`** hook timing out. In run `30572654711` the last named test passes at `18:58:38`, and the failure fires **exactly 120 s later** at `19:00:38` (= `setDefaultTimeout(120000)` + overhead).
- `server.kill()` signals only the direct `bunx` child. The tree it spawned (`bunx → next dev → next-server → Turbopack workers`) survives, so `.exited` never resolves and the hook runs out the 120 s timeout.

The teardown code has been unchanged since PR #81; PR #97 (`fix(routes): make docs root canonical`) made the root route a heavier compiled render, which pushed the SIGTERM-doesn't-cleanly-exit defect past the 120 s threshold deterministically.

> Note: PR #102 (`ci/bound-workflow-runtime`, which only adds `timeout-minutes: 30`) **does not fix this** — it bounds GitHub's *job* timeout, but the job finishes in ~3–6 min and the 120 s is Bun's *per-hook* timeout. Different layer. This PR is the actual fix; #102 can be closed.

## What changed

In `tests/e2e/llm-endpoints.test.ts`, one surgical change to teardown:

1. Spawn the dev server with `detached: true` so it leads its own process group.
2. Add a `killProcessGroup(pid, signal)` helper that signals the whole group (`process.kill(-pid, …)`), with a fallback to the direct child.
3. Rewrite `afterAll` to: SIGTERM the group → race `.exited` against a 3 s budget → escalate to SIGKILL if it hasn't exited.

The awaited exit is now **bounded**, so teardown can no longer hang regardless of how the child responds to SIGTERM — and the full process tree is reaped, keeping the port/CPU free for the later Chromium imagegen tests (the original intent of `afterAll`'s comment).

## Validation

- `bun run typecheck` — pass
- `bunx biome check tests/e2e/llm-endpoints.test.ts` — pass
- `bun test tests/e2e/llm-endpoints.test.ts` — **22 pass, 0 fail** (54 s; teardown completes cleanly)
- Hosted CI is the final confirmation (the hang is `ubuntu-latest`-specific and doesn't reproduce in this sandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
