### PR TITLE
fix(home): keep a single main landmark on the homepage

### DIFF
--- a/app/(home)/_pages/page.en.tsx
+++ b/app/(home)/_pages/page.en.tsx
@@ -20,7 +20,7 @@ import SteelLogo from '@/public/images/logo.png';
 
 export default function HomePage() {
   return (
-    <main className="space-y-10 max-w-[1024px] w-full mx-auto ">
+    <div className="space-y-10 max-w-[1024px] w-full mx-auto ">
       <div className="px-8 py-[56px]">
         <div className="space-y-10">
           <header className="space-y-1">
@@ -208,6 +208,6 @@ export default function HomePage() {
           </section>
         </div>
       </div>
-    </main>
+    </div>
   );
 }

--- a/tests/e2e/llm-endpoints.test.ts
+++ b/tests/e2e/llm-endpoints.test.ts
@@ -298,6 +298,7 @@ describe('.md suffix end-to-end', () => {
       .find((tag) => tag.includes('height:188px') && tag.includes('width:188px'));
 
     expect(body.match(/<h1\b/g)).toHaveLength(1);
+    expect(body.match(/<main\b/g)).toHaveLength(1);
     expect(body).toContain('<h1 class="text-3xl">Steel Documentation</h1>');
     expect(animatedLogo).toContain('class="shrink-0"');
     expect(body).toContain(


### PR DESCRIPTION
## Summary
- The homepage renders through DocsLayout, which already provides the `main#nd-docs-layout` landmark. The page-level `<main>` in `app/(home)/_pages/page.en.tsx` created a nested duplicate main landmark, which is invalid HTML and confuses assistive tech.
- Swapped the inner wrapper to a `div`, keeping the className unchanged, so the layout's main remains the single landmark. PR #98 fixed the heading semantics but missed this.
- `app/(home)/_pages/` has no other page variants, so this is the only page-level fix needed.

## Test plan
- Added an assertion to the homepage semantics e2e test that the rendered homepage contains exactly one `<main` element. Verified it fails on the old markup (2 matches) and passes with the fix.
- `bun test tests/e2e/llm-endpoints.test.ts`: 22 pass, 0 fail.
- `bun run check` and `bun run typecheck`: clean.