### PR TITLE
test(middleware,robots): guard the vary header and crawl allowlist

### DIFF
--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -83,6 +83,22 @@ describe('middleware .md suffix handling', () => {
     expect(varyTokens(response)).not.toEqual(expect.arrayContaining(['accept', 'user-agent']));
   });
 
+  test('varies negotiated docs URLs on accept and user-agent', () => {
+    // The markdown rewrite and the HTML pass-through share one cache key,
+    // so both responses must carry the Vary tokens from appendMarkdownVaryHeader.
+    const rewritten = middleware(
+      new NextRequest('http://localhost/overview/steel-cli', {
+        headers: { accept: 'text/html', 'user-agent': 'claude-code/1.0' },
+      }),
+    );
+    expect(rewritten.headers.get('x-middleware-rewrite')).not.toBeNull();
+    expect(varyTokens(rewritten)).toEqual(expect.arrayContaining(['accept', 'user-agent']));
+
+    const passedThrough = middleware(browserRequest('http://localhost/overview/steel-cli'));
+    expect(passedThrough.headers.get('x-middleware-rewrite')).toBeNull();
+    expect(varyTokens(passedThrough)).toEqual(expect.arrayContaining(['accept', 'user-agent']));
+  });
+
   test('passes browser navigation at the homepage through', () => {
     const response = middleware(browserRequest('http://localhost/'));
     expect(response.headers.get('x-middleware-rewrite')).toBeNull();

--- a/tests/robots-txt.test.ts
+++ b/tests/robots-txt.test.ts
@@ -95,4 +95,14 @@ describe('robots.txt content signals', () => {
     expect(groups.get('ClaudeBot')).toContain('Allow: /');
     expect(ROBOTS).toContain('Sitemap: https://docs.steel.dev/sitemap.xml');
   });
+
+  test('contains no Disallow directives in any group', () => {
+    // The docs are fully public; a blanket Disallow would silently deindex the site.
+    for (const [agent, directives] of groups) {
+      const disallows = directives.filter((directive) =>
+        directive.toLowerCase().startsWith('disallow:'),
+      );
+      expect(disallows, `${agent} blocks crawling with ${disallows.join(', ')}`).toEqual([]);
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Two test-only regression guards, no production code changes.

- **Vary header**: the middleware suite only asserted that the homepage does not vary, so deleting `withMarkdownVary` kept every test green while shipping a cache-poisoning regression. New test asserts that a negotiated docs URL (`/overview/steel-cli`) carries `Vary: Accept, User-Agent` on both the markdown rewrite path and the HTML pass-through path.
- **robots.txt**: the suite checked for `Allow: /` but never for blocking rules, so a blanket `Disallow: /` would pass green. New test asserts that no user-agent group contains any `Disallow` directive, which matches the current robots.txt.

## Test plan

- `bun test tests/middleware.test.ts tests/robots-txt.test.ts`: 21 pass
- Full `bun test`: 300 pass across 22 files
- `bun run check`: clean
- Regression sanity check: temporarily neutered `withMarkdownVary` in `middleware.ts`, confirmed the new Vary test fails, restored it before committing