### PR TITLE
fix(tests): route the fetch mock cast through unknown to satisfy tsc

### DIFF
--- a/tests/agent-skills-index.test.ts
+++ b/tests/agent-skills-index.test.ts
@@ -306,7 +306,7 @@ describe('GitHub transport error classification', () => {
   test('classifies fetch network failures as skippable transport errors', async () => {
     const originalFetch = globalThis.fetch;
     globalThis.fetch = (() =>
-      Promise.reject(new TypeError('Unable to connect'))) as typeof globalThis.fetch;
+      Promise.reject(new TypeError('Unable to connect'))) as unknown as typeof globalThis.fetch;
 
     try {
       const error = await githubFetch('https://api.github.com/repos/steel-dev/skills', {}).catch(


### PR DESCRIPTION
## Summary

CI on main fails typecheck since #108: the fetch mock in tests/agent-skills-index.test.ts casts a bare function directly to typeof fetch, and Bun's fetch type also requires a preconnect property (TS2352). Routing the cast through unknown is the standard fix tsc itself suggests. Test behavior is unchanged.

## Test plan

- bun run typecheck: clean (previously failed on line 308)
- bun test tests/agent-skills-index.test.ts: 32 pass, 0 fail
- bun run check: clean