### PR TITLE
test(imagegen): double the chromium timeout headroom for loaded CI runners

### DIFF
--- a/tests/imagegen/e2e/cli.test.ts
+++ b/tests/imagegen/e2e/cli.test.ts
@@ -9,8 +9,8 @@ import { fileURLToPath } from 'node:url';
 import { PNG } from 'pngjs';
 
 // Each case renders a card in a subprocess, launching headless Chromium, which is
-// slow enough on a loaded two-core CI runner to blow past a 30s budget.
-setDefaultTimeout(120000);
+// slow enough on a loaded two-core CI runner to blow past a 120s budget.
+setDefaultTimeout(240000);
 
 const CLI = fileURLToPath(new URL('../../../scripts/changelog/imagegen/cli.ts', import.meta.url));
 

--- a/tests/imagegen/integration/render.test.ts
+++ b/tests/imagegen/integration/render.test.ts
@@ -5,8 +5,8 @@ import assert from 'node:assert/strict';
 import { PNG } from 'pngjs';
 
 // The render hook launches headless Chromium, which is slow enough on a loaded
-// two-core CI runner to blow past a 30s budget.
-setDefaultTimeout(120000);
+// two-core CI runner to blow past a 120s budget.
+setDefaultTimeout(240000);
 
 import { renderCard } from '../../../scripts/changelog/imagegen/render';
 import { CARD_HEIGHT, CARD_WIDTH } from '../../../scripts/changelog/imagegen/template';

--- a/tests/imagegen/integration/run.test.ts
+++ b/tests/imagegen/integration/run.test.ts
@@ -5,8 +5,8 @@ import assert from 'node:assert/strict';
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 
 // The pipeline launches a fresh headless Chromium per render. On a loaded
-// two-core CI runner one launch has taken over 30s, so allow generous headroom.
-setDefaultTimeout(120000);
+// two-core CI runner one launch has taken over 120s, so allow generous headroom.
+setDefaultTimeout(240000);
 
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';


### PR DESCRIPTION
## Summary

Three of the last five CI runs on main failed on imagegen integration tests timing out at exactly 120s. The slow step is launching a fresh headless Chromium per render on a loaded two-core runner; the OpenAI image call is already faked in these tests. Raises setDefaultTimeout from 120s to 240s in the three imagegen test files and updates the comments to match the observed worst case.

## Test plan

- bun test tests/imagegen: 79 pass, 0 fail (5.8s locally; the timeout only matters under CI load)
- bun run check: clean

Note: main's typecheck is currently red from #108 (fixed by #109); unrelated to this change.