### PR TITLE
feat(aeo): carry production claims in the canonical identity and pricing snippets

### DIFF
--- a/app/(home)/_pages/page.en.tsx
+++ b/app/(home)/_pages/page.en.tsx
@@ -49,9 +49,10 @@ export default function HomePage() {
               <div className="flex flex-col [&_p]:mb-6 space-y-3">
                 <h1 className="text-3xl">Steel Documentation</h1>
                 <p>
-                  Steel is an open-source browser API for AI agents and automation. Use these docs
-                  to create cloud browser sessions, connect your automation tools, and configure
-                  proxies, CAPTCHA solving, credentials, and files.
+                  Steel is the open-source browser API for AI agents — managed cloud browsers with
+                  stealth, residential proxies, CAPTCHA solving, persistent profiles, session
+                  replays, and agent observability. Use these docs to create cloud browser sessions
+                  and connect your automation tools.
                 </p>
               </div>
             </div>

--- a/app/og/[...slug]/route.tsx
+++ b/app/og/[...slug]/route.tsx
@@ -31,7 +31,8 @@ export async function GET(_req: NextRequest, props: { params: Promise<{ slug: st
 
   const title = page?.data.title ?? 'Steel Docs';
   const description =
-    page?.data.description ?? 'Documentation for Steel: the open-source browser API for AI agents.';
+    page?.data.description ??
+    'Documentation for Steel: the open-source browser API for AI agents — cloud browsers with stealth, proxies, CAPTCHA solving, and observability.';
   const section = slug?.[0] === 'en' ? slug?.[1] : slug?.[0];
   const sectionLabel = section ? (SECTION_LABELS[section] ?? '') : '';
   const accent = section ? (SECTION_ACCENTS[section] ?? '#a3a3a3') : '#a3a3a3';

--- a/content/docs/overview/pricinglimits.mdx
+++ b/content/docs/overview/pricinglimits.mdx
@@ -1,6 +1,6 @@
 ---
 title: Pricing/Limits
-description: Steel pricing for Launch, Scale, and Enterprise plans, including usage credits, metered rates, and plan limits.
+description: "Steel pricing: start free with $30 in usage credits (about 300 browser hours). Browser hours from $0.08/hour, CAPTCHA solves from $1/1k, proxies from $6/GB across Launch, Scale, and Enterprise plans."
 sidebarTitle: Pricing/Limits
 llm: true
 ---

--- a/lib/agent-instructions.ts
+++ b/lib/agent-instructions.ts
@@ -3,7 +3,8 @@
 
 export const AGENT_INSTRUCTIONS = `# Steel Documentation
 
-> Steel is a cloud browser API for AI agents and developers.
+> Steel is the open-source browser API for AI agents — managed cloud browsers with stealth,
+> residential proxies, CAPTCHA solving, persistent profiles, session replays, and agent observability.
 > Use Steel to launch cloud browsers, scrape content, and automate web tasks.
 
 ## Quick Reference

--- a/lib/structured-data.ts
+++ b/lib/structured-data.ts
@@ -6,7 +6,7 @@ export const STEEL_ORGANIZATION_ID = `${DOCS_URL}/#organization`;
 export const DOCS_WEBSITE_ID = `${DOCS_URL}/#website`;
 export const DOCS_SITE_NAME = 'Steel Docs';
 export const DOCS_SITE_DESCRIPTION =
-  "Documentation for Steel, an open-source browser API for AI agents and automation. Create cloud browser sessions with Steel's APIs, SDKs, and integrations.";
+  'Documentation for Steel, the open-source browser API for AI agents — managed cloud browsers with stealth, residential proxies, CAPTCHA solving, persistent profiles, session replays, and agent observability.';
 export const STEEL_SAME_AS = ['https://github.com/steel-dev', 'https://x.com/steeldotdev'] as const;
 export const STEEL_LOGO_URL = `${DOCS_URL}/images/logo.png`;
 

--- a/tests/e2e/llm-endpoints.test.ts
+++ b/tests/e2e/llm-endpoints.test.ts
@@ -327,7 +327,7 @@ describe('.md suffix end-to-end', () => {
     expect(body).toContain('<h1 class="text-3xl">Steel Documentation</h1>');
     expect(animatedLogo).toContain('class="shrink-0"');
     expect(body).toContain(
-      'Steel is an open-source browser API for AI agents and automation. Use these docs to create cloud browser sessions, connect your automation tools, and configure proxies, CAPTCHA solving, credentials, and files.',
+      'Steel is the open-source browser API for AI agents — managed cloud browsers with stealth, residential proxies, CAPTCHA solving, persistent profiles, session replays, and agent observability. Use these docs to create cloud browser sessions and connect your automation tools.',
     );
     expect(body).toContain(
       '<section class="space-y-5" aria-labelledby="getting-started-and-apis">',


### PR DESCRIPTION
## Why

A live ChatGPT answer to "best cloud browser for ai agent" (112 retrieved sources analyzed) showed how answer engines pick recommendations: they build a per-vendor attribute profile from claims **corroborated across retrieved snippets**, then assign each vendor one slot. Browserbase won "best overall" with 15 docs pages all repeating "proxies, CAPTCHA solving, observability." Steel won only "open source / self-hostable" — because every Steel snippet leads with "open-source browser API" and claims nothing else.

Steel has every feature on the answer's "best overall" checklist, but no retrieved snippet said them together.

## What

**Canonical identity sentence** — one sentence, applied to all four identity surfaces, keeping the open-source moat and adding the production attributes (stealth, residential proxies, CAPTCHA solving, persistent profiles, session replays, agent observability):

- `lib/structured-data.ts` — `DOCS_SITE_DESCRIPTION` (JSON-LD `WebSite`)
- `app/og/[...slug]/route.tsx` — OG description fallback (shorter variant; renders inside an image)
- `app/(home)/_pages/page.en.tsx` — homepage prose
- `lib/agent-instructions.ts` — llms.txt / AGENTS.md preamble (regenerated output verified)

**Pricing snippet** — `content/docs/overview/pricinglimits.mdx` description becomes one quotable claim with current rates ("start free with $30 in usage credits (about 300 browser hours), browser hours from $0.08/hour…"). The previous snippet retrieval engines extracted was flattened table cells: "Browser hours $0.10/hour $0.08/hour Custom $10/".

Also updates the e2e assertion in `tests/e2e/llm-endpoints.test.ts` that pins the homepage sentence.

## Verification

- `bun run lint`, `bun run typecheck`, `bun run spell` — clean
- `bun test tests/` — 316 pass, 0 fail
- `bun run build` — clean; regenerated `llms.txt` preamble carries the new sentence

🤖 Generated with [Claude Code](https://claude.com/claude-code)