### PR TITLE
fix(llms): restore homepage markdown negotiation

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -33,6 +33,16 @@ export default function middleware(request: NextRequest) {
 
   const wantsMarkdown = shouldServeMarkdown(request.headers);
 
+  if (pathname === '/') {
+    if (wantsMarkdown) {
+      const rewriteUrl = request.nextUrl.clone();
+      rewriteUrl.pathname = '/AGENTS.md';
+      return withMarkdownVary(NextResponse.rewrite(rewriteUrl));
+    }
+
+    return withMarkdownVary(NextResponse.next());
+  }
+
   if (!isNegotiableDocsPath(pathname)) {
     return NextResponse.next();
   }

--- a/tests/e2e/llm-endpoints.test.ts
+++ b/tests/e2e/llm-endpoints.test.ts
@@ -201,11 +201,13 @@ describe('.md suffix end-to-end', () => {
     }
   });
 
-  test('keeps the canonical HTML homepage indexable for Markdown requests', async () => {
+  test('negotiates markdown at the canonical homepage', async () => {
     const response = await fetch(BASE_URL, { headers: { accept: 'text/markdown' } });
     expect(response.status).toBe(200);
-    expect(response.headers.get('content-type')).toStartWith('text/html');
+    expect(response.headers.get('content-type')).toStartWith('text/markdown');
     expect(response.headers.get('x-robots-tag')).toBeNull();
+    expect(varyTokens(response)).toEqual(expect.arrayContaining(['accept', 'user-agent']));
+    expect(await response.text()).toStartWith('> Full docs index: https://docs.steel.dev/llms.txt');
   });
 
   test('llms-full.txt does not repeat the index pointer', async () => {
@@ -227,7 +229,7 @@ describe('.md suffix end-to-end', () => {
     }
   });
 
-  test('keeps the canonical homepage HTML-only for Markdown clients', async () => {
+  test('serves Markdown clients markdown at the canonical homepage', async () => {
     const headersToTest = [
       ...MARKDOWN_USER_AGENTS.map((userAgent) => ({
         accept: 'text/html',
@@ -239,8 +241,12 @@ describe('.md suffix end-to-end', () => {
     for (const headers of headersToTest) {
       const response = await fetch(BASE_URL, { headers });
       expect(response.status).toBe(200);
-      expect(response.headers.get('content-type')).toStartWith('text/html');
+      expect(response.headers.get('content-type')).toStartWith('text/markdown');
       expect(response.headers.get('x-robots-tag')).toBeNull();
+      expect(varyTokens(response)).toEqual(expect.arrayContaining(['accept', 'user-agent']));
+      expect(await response.text()).toStartWith(
+        '> Full docs index: https://docs.steel.dev/llms.txt',
+      );
     }
   });
 

--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -66,6 +66,18 @@ describe('middleware .md suffix handling', () => {
   test.each([
     { accept: 'text/markdown', 'user-agent': 'curl/8.7.1' },
     { accept: 'text/html', 'user-agent': 'claude-code/1.0' },
+  ])('serves the homepage as markdown for $user-agent', (headers) => {
+    const response = middleware(new NextRequest('http://localhost/', { headers }));
+    const rewrite = response.headers.get('x-middleware-rewrite');
+    expect(rewrite).not.toBeNull();
+    expect(new URL(rewrite as string).pathname).toBe('/AGENTS.md');
+    expect(response.status).toBe(200);
+    expect(response.headers.get('location')).toBeNull();
+    expect(varyTokens(response)).toEqual(expect.arrayContaining(['accept', 'user-agent']));
+  });
+
+  test.each([
+    { accept: 'text/html', 'user-agent': 'curl/8.7.1' },
     { accept: 'text/html', 'user-agent': 'Googlebot/2.1' },
     { accept: 'text/html', 'user-agent': 'GPTBot/1.2' },
     { accept: 'text/html', 'user-agent': 'OAI-SearchBot/1.0' },
@@ -80,7 +92,7 @@ describe('middleware .md suffix handling', () => {
     expect(response.headers.get('x-middleware-rewrite')).toBeNull();
     expect(response.status).toBe(200);
     expect(response.headers.get('location')).toBeNull();
-    expect(varyTokens(response)).not.toEqual(expect.arrayContaining(['accept', 'user-agent']));
+    expect(varyTokens(response)).toEqual(expect.arrayContaining(['accept', 'user-agent']));
   });
 
   test('varies negotiated docs URLs on accept and user-agent', () => {
@@ -104,6 +116,7 @@ describe('middleware .md suffix handling', () => {
     expect(response.headers.get('x-middleware-rewrite')).toBeNull();
     expect(response.status).toBe(200);
     expect(response.headers.get('location')).toBeNull();
+    expect(varyTokens(response)).toEqual(expect.arrayContaining(['accept', 'user-agent']));
   });
 
   test('does not rewrite /AGENTS.md, even for markdown user agents', () => {


### PR DESCRIPTION
## Summary

- restore `Accept: text/markdown` negotiation at the canonical homepage
- rewrite Markdown homepage requests internally to `/AGENTS.md` while keeping HTML as the default
- vary homepage responses on `Accept` and `User-Agent`
- add middleware and end-to-end regression coverage

## Root cause

PR #97 made `/` the canonical docs URL, added it to the negotiation exclusions, and removed the homepage Markdown rewrite. Nested documentation pages continued negotiating correctly, but homepage scanners such as Is It Agent Ready received `text/html` for an explicit Markdown request.

## Impact

Requests to `/` with `Accept: text/markdown` now return `text/markdown`. Browser and crawler requests without Markdown negotiation continue receiving the canonical HTML homepage.

## Validation

- `bun test tests/markdown-negotiation.test.ts tests/middleware.test.ts tests/e2e/llm-endpoints.test.ts` — 66 passed
- `bun run check`
- `bun run validate-links`
- `bun run build`
- `git diff --check`
