### PR TITLE
fix(home): stack hero content on mobile

### DIFF
--- a/.impeccable/live/config.json
+++ b/.impeccable/live/config.json
@@ -1,0 +1,6 @@
+{
+  "files": ["app/layout.tsx"],
+  "insertBefore": "</body>",
+  "commentSyntax": "jsx",
+  "cspChecked": true
+}

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,41 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+AI engineers and developers evaluating Steel or integrating its browser infrastructure into
+agents and automation. They need to understand capabilities quickly, find accurate implementation
+details, and move from evaluation to a working integration.
+
+## Product Purpose
+
+Steel Docs explains Steel's browser APIs, SDKs, integrations, and operational capabilities. It
+should make the product easy to evaluate and help developers build reliable cloud-browser
+workflows without obscuring technical detail.
+
+## Brand Personality
+
+Direct, technical, and confident. The experience should feel authoritative and practical while
+remaining approachable to developers encountering Steel for the first time.
+
+## Anti-references
+
+Avoid marketing-heavy layouts, vague claims, excessive visible copy, and ornamental treatments
+that compete with documentation. Do not trade accurate, indexable product information for a
+minimal appearance.
+
+## Design Principles
+
+- Put the developer's next action within easy reach.
+- Preserve technical accuracy and quotable product identity.
+- Keep content readable at every viewport width.
+- Use visual hierarchy to reduce cognitive load without hiding essential information.
+- Prefer focused, established patterns over decorative novelty.
+
+## Accessibility & Inclusion
+
+Target WCAG 2.1 AA. Maintain readable contrast, keyboard access, visible focus states, reduced
+motion support, semantic structure, and responsive layouts that remain usable at 320px wide.

--- a/app/(home)/_pages/page.en.tsx
+++ b/app/(home)/_pages/page.en.tsx
@@ -21,12 +21,12 @@ import SteelLogo from '@/public/images/logo.png';
 export default function HomePage() {
   return (
     <div className="space-y-10 max-w-[1024px] w-full mx-auto ">
-      <div className="px-8 py-[56px]">
+      <div className="px-6 py-10 sm:px-8 sm:py-14">
         <div className="space-y-10">
           <header className="space-y-1">
-            <div className="flex space-x-6 items-end">
+            <div className="flex flex-col gap-6 sm:flex-row sm:items-end">
               <LiquidMetal1
-                className="shrink-0"
+                className="shrink-0 self-center sm:self-auto"
                 image={SteelLogo as HTMLImageElement}
                 speed={1}
                 colorBack="#00000000"
@@ -46,7 +46,7 @@ export default function HomePage() {
                   width: '188px',
                 }}
               />
-              <div className="flex flex-col [&_p]:mb-6 space-y-3">
+              <div className="flex min-w-0 flex-col space-y-3">
                 <h1 className="text-3xl">Steel Documentation</h1>
                 <p>
                   Steel is the open-source browser API for AI agents — managed cloud browsers with


### PR DESCRIPTION
## What changed

- stack the homepage logo above the introduction on mobile widths
- preserve the existing side-by-side desktop composition
- keep the canonical SEO/AEO identity sentence from #113 unchanged
- add responsive padding and a minimum-width safeguard for the copy
- capture the existing docs product context and configure the frontend live-preview workflow

## Why

The longer canonical identity sentence introduced in #113 made the fixed 188px logo and copy compete
for the same narrow mobile row. Because the row was bottom-aligned, the logo was pushed down while
the text wrapped into a very narrow column.

## Impact

The homepage hero is readable at phone widths, the logo keeps a stable position, and the
answer-engine identity copy remains visible and unchanged.

## Validation

- `bunx biome check 'app/(home)/_pages/page.en.tsx'`
- `bun run typecheck`
- rendered locally at 320px, 390px, 768px, and 1280px with no horizontal overflow

`bun run check` also ran, but the repository baseline currently reports missing trailing newlines
in `scripts/seo/pulse/snapshots/tech-2026-07.json` and
`scripts/seo/pulse/snapshots/volumes-2026-07.json`; this PR does not touch those files.
