### PR TITLE
feat(changelog): commit an auditable evidence ledger for filtered sources

### DIFF
--- a/.github/workflows/changelog-draft.yml
+++ b/.github/workflows/changelog-draft.yml
@@ -107,6 +107,7 @@ jobs:
           path: |
             ${{ steps.generate.outputs.draft_path }}
             ${{ steps.generate.outputs.pr_body_path }}
+            ${{ steps.generate.outputs.ledger_path }}
             ${{ steps.generate.outputs.cover_workdir }}
 
       - name: Create draft pull request
@@ -128,4 +129,5 @@ jobs:
             content/docs/changelog/**
             public/changelog/llms.txt
             public/images/changelog/**
+            scripts/changelog/audit/**
             scripts/changelog/state.json

--- a/scripts/changelog/README.md
+++ b/scripts/changelog/README.md
@@ -52,10 +52,33 @@ published changelog revisions.
 
 ## Auditing filtered evidence
 
-The generated PR body and the Actions log only show aggregate exclusion counts, because both are
-public and excluded groups can reference private repositories. To audit individual exclusion
-decisions, run preview mode for the same window and inspect `excluded-groups.json` in the
-temporary directory it prints. `source-facts.json` holds the eligible groups sent to the model.
+Every run builds an evidence ledger recording each source group the filter dropped, and commits it
+to `scripts/changelog/audit/<n>.json` in the draft pull request. Actions artifacts expire, so the
+committed ledger is what makes an exclusion decision answerable months later.
+
+Each exclusion carries a `confidence`:
+
+- `heuristic`: a regex, a commit-type check, or missing changed-file data dropped the group, so a
+  real change can hide behind it. The PR body lists these in an open **Needs review** block for a
+  reviewer to confirm one by one.
+- `structural`: the group was dropped for what it is rather than what it says (an automated author,
+  a disabled source, a generated changelog, a submodule pointer). The PR body folds these away.
+
+The ledger also reconciles collected commits against logical changes, eligible groups, and excluded
+groups. Commits dropped by author never reach a group, so they are recorded separately in
+`authorSkipped`; a non-zero `unaccounted` means a group disappeared between grouping and
+classification and should be investigated.
+
+Repository visibility in `config.ts` decides how much of a source reaches the public PR body.
+Private sources keep their links, SHAs, and file counts but not their pull request titles, commit
+subjects, or file paths, and an unconfigured repository is treated as private. The same rule
+applies to the model's own discard list: its prose is kept only when every reference behind it is
+public.
+
+A quiet week opens no pull request, so its ledger is only rendered into the Actions run log. Run
+preview mode for the same window to reconstruct it. Preview writes `ledger.json` next to
+`source-facts.json` (the eligible groups sent to the model) and `model-output.json` in the
+temporary directory it prints.
 
 ## Recovering from a failed run
 

--- a/scripts/changelog/config.ts
+++ b/scripts/changelog/config.ts
@@ -11,12 +11,19 @@ export type ChangelogSourceKind =
 
 export type ChangelogSourceMode = 'direct' | 'derived' | 'excluded';
 
+/**
+ * Whether a monitored repository's commit prose can appear in the public docs PR. Private
+ * sources keep their links and SHAs in the audit ledger but never their titles or paths.
+ */
+export type ChangelogRepositoryVisibility = 'private' | 'public';
+
 export interface ChangelogRepository {
   owner: string;
   repo: string;
   branch: string;
   kind: ChangelogSourceKind;
   mode: ChangelogSourceMode;
+  visibility: ChangelogRepositoryVisibility;
 }
 
 export interface ChangelogSubmoduleSource {
@@ -42,6 +49,7 @@ export const CHANGELOG_APPLICATION_REPOSITORY: ChangelogRepository = {
   branch: 'release',
   kind: 'application',
   mode: 'direct',
+  visibility: 'private',
 };
 
 export const CHANGELOG_BROWSER_REPOSITORY: ChangelogRepository = {
@@ -50,6 +58,7 @@ export const CHANGELOG_BROWSER_REPOSITORY: ChangelogRepository = {
   branch: 'main',
   kind: 'browser',
   mode: 'derived',
+  visibility: 'public',
 };
 
 export const CHANGELOG_REPOSITORIES: ChangelogRepository[] = [
@@ -61,6 +70,7 @@ export const CHANGELOG_REPOSITORIES: ChangelogRepository[] = [
     branch: 'main',
     kind: 'infra',
     mode: 'excluded',
+    visibility: 'private',
   },
   {
     owner: 'steel-dev',
@@ -68,6 +78,7 @@ export const CHANGELOG_REPOSITORIES: ChangelogRepository[] = [
     branch: 'main',
     kind: 'inactive',
     mode: 'excluded',
+    visibility: 'public',
   },
   {
     owner: 'steel-dev',
@@ -75,6 +86,7 @@ export const CHANGELOG_REPOSITORIES: ChangelogRepository[] = [
     branch: 'main',
     kind: 'cookbook',
     mode: 'direct',
+    visibility: 'public',
   },
   {
     owner: 'steel-dev',
@@ -82,6 +94,7 @@ export const CHANGELOG_REPOSITORIES: ChangelogRepository[] = [
     branch: 'main',
     kind: 'inactive',
     mode: 'excluded',
+    visibility: 'public',
   },
   {
     owner: 'steel-dev',
@@ -89,6 +102,7 @@ export const CHANGELOG_REPOSITORIES: ChangelogRepository[] = [
     branch: 'main',
     kind: 'leaderboard',
     mode: 'direct',
+    visibility: 'public',
   },
   {
     owner: 'steel-dev',
@@ -96,6 +110,7 @@ export const CHANGELOG_REPOSITORIES: ChangelogRepository[] = [
     branch: 'main',
     kind: 'ecosystem',
     mode: 'excluded',
+    visibility: 'public',
   },
   {
     owner: 'steel-dev',
@@ -103,6 +118,7 @@ export const CHANGELOG_REPOSITORIES: ChangelogRepository[] = [
     branch: 'main',
     kind: 'cli',
     mode: 'direct',
+    visibility: 'public',
   },
   {
     owner: 'steel-dev',
@@ -110,6 +126,7 @@ export const CHANGELOG_REPOSITORIES: ChangelogRepository[] = [
     branch: 'main',
     kind: 'docs',
     mode: 'direct',
+    visibility: 'public',
   },
 ];
 
@@ -135,6 +152,17 @@ export const CHANGELOG_PLACEHOLDER_IMAGE: PlaceholderImageConfig = {
 };
 
 export const CHANGELOG_PROMPT_FILE = 'scripts/changelog/prompt.md';
+
+/**
+ * Every run commits its evidence ledger here so exclusion decisions stay reviewable after the
+ * Actions artifacts for the run have expired.
+ */
+export const CHANGELOG_AUDIT_DIRECTORY = 'scripts/changelog/audit';
+/**
+ * How many heuristic exclusions the PR body lists before deferring to the ledger. The block is
+ * meant to be read in full during review, so an overflow is stated rather than truncated silently.
+ */
+export const NEEDS_REVIEW_PR_BODY_LIMIT = 10;
 
 export const CHANGELOG_CONTEXT_FILES: PromptContextFile[] = [
   {

--- a/scripts/changelog/ledger.ts
+++ b/scripts/changelog/ledger.ts
@@ -1,0 +1,301 @@
+// ABOUTME: Builds the per-run changelog evidence ledger recording every source group the filter
+// ABOUTME: dropped, redacted by repository visibility, and renders its PR body review section.
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import {
+  CHANGELOG_AUDIT_DIRECTORY,
+  CHANGELOG_REPOSITORIES,
+  type ChangelogRepositoryVisibility,
+  NEEDS_REVIEW_PR_BODY_LIMIT,
+} from './config';
+import type {
+  ChangeGroup,
+  EligibilityReason,
+  ExcludedChangeGroup,
+  WindowSelection,
+} from './source';
+
+export type ExclusionReason = Exclude<EligibilityReason, 'eligible'>;
+
+/**
+ * `heuristic` reasons come from regexes, commit types, or missing data, so a real change can hide
+ * behind them and a reviewer has to confirm each one. `structural` reasons follow from what a
+ * group is rather than what it says, so they can be read in bulk.
+ */
+export type ExclusionConfidence = 'heuristic' | 'structural';
+
+const HEURISTIC_EXCLUSION_REASONS: ExclusionReason[] = [
+  'benchmark_maintenance',
+  'internal_only',
+  // A group with no changed files was dropped for lost evidence, not for being uninteresting.
+  'missing_changed_files',
+  'non_material_docs',
+  'non_recipe_change',
+  'routine_maintenance',
+];
+
+export interface LedgerCommit {
+  shortSha: string;
+  url: string;
+  subject: string | null;
+}
+
+export interface LedgerPullRequest {
+  number: number;
+  url: string;
+  title: string | null;
+}
+
+export interface LedgerExclusion {
+  reason: ExclusionReason;
+  confidence: ExclusionConfidence;
+  key: string;
+  repo: string;
+  visibility: ChangelogRepositoryVisibility;
+  redacted: boolean;
+  pullRequest: LedgerPullRequest | null;
+  commits: LedgerCommit[];
+  changedFileCount: number;
+  changedFiles: string[] | null;
+}
+
+export interface LedgerAuthorSkip {
+  repo: string;
+  sha: string;
+  url: string;
+  author: string;
+}
+
+export interface LedgerModelDiscard {
+  text: string | null;
+  reason: string;
+  redacted: boolean;
+  references: Array<{ label: string; url: string }>;
+}
+
+export interface LedgerReconciliation {
+  commitsCollected: number;
+  authorSkippedCommits: number;
+  logicalChanges: number;
+  eligible: number;
+  excluded: number;
+  unaccounted: number;
+}
+
+export interface EvidenceLedger {
+  changelogNumber: number;
+  window: WindowSelection;
+  reconciliation: LedgerReconciliation;
+  exclusions: LedgerExclusion[];
+  authorSkipped: LedgerAuthorSkip[];
+  modelDiscarded: LedgerModelDiscard[];
+}
+
+export interface DiscardedItemInput {
+  text: string;
+  reason: string;
+  references: Array<{ label: string; url: string }>;
+}
+
+export function getExclusionConfidence(reason: ExclusionReason): ExclusionConfidence {
+  return HEURISTIC_EXCLUSION_REASONS.includes(reason) ? 'heuristic' : 'structural';
+}
+
+/**
+ * An unconfigured repository is treated as private so a newly monitored source cannot leak its
+ * commit prose into the public PR body before someone declares its visibility.
+ */
+export function getRepositoryVisibility(
+  owner: string,
+  repo: string,
+): ChangelogRepositoryVisibility {
+  const configured = CHANGELOG_REPOSITORIES.find(
+    (repository) => repository.owner === owner && repository.repo === repo,
+  );
+
+  return configured?.visibility || 'private';
+}
+
+function isPublicRepositoryUrl(url: string): boolean {
+  const match = /^https:\/\/github\.com\/([^/]+)\/([^/]+)/.exec(url);
+
+  if (!match) {
+    return false;
+  }
+
+  return getRepositoryVisibility(match[1], match[2]) === 'public';
+}
+
+function buildExclusion(excluded: ExcludedChangeGroup): LedgerExclusion {
+  const { group, reason } = excluded;
+  const visibility = getRepositoryVisibility(group.owner, group.repo);
+  const redacted = visibility === 'private';
+
+  return {
+    reason,
+    confidence: getExclusionConfidence(reason),
+    key: group.key,
+    repo: `${group.owner}/${group.repo}`,
+    visibility,
+    redacted,
+    pullRequest: group.pullRequest
+      ? {
+          number: group.pullRequest.number,
+          url: group.pullRequest.url,
+          title: redacted ? null : group.pullRequest.title,
+        }
+      : null,
+    commits: group.commits.map((commit) => ({
+      shortSha: commit.shortSha,
+      url: commit.url,
+      subject: redacted ? null : commit.subject,
+    })),
+    changedFileCount: group.changedFiles.length,
+    changedFiles: redacted ? null : group.changedFiles.map((file) => file.filename),
+  };
+}
+
+function buildModelDiscard(item: DiscardedItemInput): LedgerModelDiscard {
+  // The model writes this prose from the evidence it was given, so it can only stay when every
+  // commit behind it is public.
+  const redacted =
+    item.references.length === 0 ||
+    !item.references.every((reference) => isPublicRepositoryUrl(reference.url));
+
+  return {
+    text: redacted ? null : item.text,
+    reason: item.reason,
+    redacted,
+    references: item.references,
+  };
+}
+
+export function buildEvidenceLedger(input: {
+  changelogNumber: number;
+  windowSelection: WindowSelection;
+  commitsCollected: number;
+  authorSkipped: LedgerAuthorSkip[];
+  logicalChanges: number;
+  eligibleGroups: ChangeGroup[];
+  excludedGroups: ExcludedChangeGroup[];
+  discardedItems: DiscardedItemInput[];
+}): EvidenceLedger {
+  const exclusions = input.excludedGroups.map(buildExclusion);
+
+  return {
+    changelogNumber: input.changelogNumber,
+    window: input.windowSelection,
+    reconciliation: {
+      commitsCollected: input.commitsCollected,
+      authorSkippedCommits: input.authorSkipped.length,
+      logicalChanges: input.logicalChanges,
+      eligible: input.eligibleGroups.length,
+      excluded: exclusions.length,
+      unaccounted: input.logicalChanges - input.eligibleGroups.length - exclusions.length,
+    },
+    exclusions,
+    authorSkipped: input.authorSkipped,
+    modelDiscarded: input.discardedItems.map(buildModelDiscard),
+  };
+}
+
+export function getEvidenceLedgerPath(changelogNumber: number): string {
+  return path.posix.join(
+    CHANGELOG_AUDIT_DIRECTORY,
+    `${String(changelogNumber).padStart(3, '0')}.json`,
+  );
+}
+
+/** Writes the ledger under `rootDirectory` and returns its repository-relative path. */
+export async function writeEvidenceLedger(
+  rootDirectory: string,
+  ledger: EvidenceLedger,
+): Promise<string> {
+  const relativePath = getEvidenceLedgerPath(ledger.changelogNumber);
+  const absolutePath = path.join(rootDirectory, relativePath);
+
+  await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+  await fs.writeFile(absolutePath, `${JSON.stringify(ledger, null, 2)}\n`);
+
+  return relativePath;
+}
+
+function renderExclusionLine(entry: LedgerExclusion): string {
+  const pullRequest = entry.pullRequest
+    ? ` [#${entry.pullRequest.number}](${entry.pullRequest.url})`
+    : ` [${entry.commits[0]?.shortSha || entry.key}](${entry.commits[0]?.url || ''})`;
+  const headline = entry.pullRequest?.title || entry.commits[0]?.subject;
+  const scale = `${entry.commits.length} commit${entry.commits.length === 1 ? '' : 's'}, ${entry.changedFileCount} file${entry.changedFileCount === 1 ? '' : 's'}`;
+
+  return `- \`${entry.reason}\` ${entry.repo}${pullRequest}${headline ? `: ${headline}` : ''} (${scale})`;
+}
+
+export function renderSourceFilteringSection(ledger: EvidenceLedger): string[] {
+  const { reconciliation } = ledger;
+  const authorSkipNote =
+    reconciliation.authorSkippedCommits > 0
+      ? ` (${reconciliation.authorSkippedCommits} skipped as an automated author before grouping)`
+      : '';
+  const lines = [
+    '## Source filtering',
+    '',
+    `- Commits collected: ${reconciliation.commitsCollected}${authorSkipNote}`,
+    `- Logical changes: ${reconciliation.logicalChanges} (${reconciliation.eligible} eligible, ${reconciliation.excluded} excluded, ${reconciliation.unaccounted} unaccounted)`,
+    `- Full ledger: \`${getEvidenceLedgerPath(ledger.changelogNumber)}\` in this pull request`,
+    '- Private sources keep their links and SHAs here but not their titles, subjects, or paths.',
+  ];
+
+  const needsReview = ledger.exclusions.filter((entry) => entry.confidence === 'heuristic');
+  const structural = ledger.exclusions.filter((entry) => entry.confidence === 'structural');
+
+  if (needsReview.length > 0) {
+    lines.push(
+      '',
+      `### Needs review (${needsReview.length})`,
+      '',
+      'A heuristic rule dropped each of these. Confirm none of them belongs in the changelog.',
+      '',
+      ...needsReview.slice(0, NEEDS_REVIEW_PR_BODY_LIMIT).map(renderExclusionLine),
+    );
+
+    if (needsReview.length > NEEDS_REVIEW_PR_BODY_LIMIT) {
+      lines.push(
+        '',
+        `${needsReview.length - NEEDS_REVIEW_PR_BODY_LIMIT} more heuristic exclusions are in the ledger.`,
+      );
+    }
+  }
+
+  if (structural.length > 0) {
+    lines.push(
+      '',
+      '<details>',
+      `<summary>Structurally excluded (${structural.length})</summary>`,
+      '',
+      ...structural.map(renderExclusionLine),
+      '',
+      '</details>',
+    );
+  }
+
+  if (ledger.modelDiscarded.length > 0) {
+    lines.push(
+      '',
+      '<details>',
+      `<summary>Discarded while drafting (${ledger.modelDiscarded.length})</summary>`,
+      '',
+      ...ledger.modelDiscarded.map((item) => {
+        const references = item.references
+          .map((reference) => `[${reference.label}](${reference.url})`)
+          .join(' ');
+        const text = item.text || '_private source_';
+
+        return `- ${text} (${item.reason})${references ? ` ${references}` : ''}`;
+      }),
+      '',
+      '</details>',
+    );
+  }
+
+  return lines;
+}

--- a/scripts/generate-changelog-draft.ts
+++ b/scripts/generate-changelog-draft.ts
@@ -23,11 +23,16 @@ import {
 } from './changelog/config';
 import { type CoverResult, generateChangelogCover } from './changelog/cover';
 import {
+  buildEvidenceLedger,
+  type EvidenceLedger,
+  type LedgerAuthorSkip,
+  renderSourceFilteringSection,
+  writeEvidenceLedger,
+} from './changelog/ledger';
+import {
   type ChangedFile,
   type ChangeGroup,
   type CommitCandidate,
-  type ExcludedChangeGroup,
-  type ExclusionSummary,
   filterEligibleChangeGroups,
   formatChangeGroupForPrompt,
   groupCommitsByPullRequest,
@@ -348,11 +353,36 @@ async function fetchGithubJson<T>(url: URL, token: string): Promise<T> {
   return (await response.json()) as T;
 }
 
+/**
+ * Commits dropped by author never reach a change group, so without this record they would be
+ * missing from every exclusion count and the ledger could not reconcile.
+ */
+const authorSkippedCommits = new Map<string, LedgerAuthorSkip>();
+
+function getCommitAuthor(commit: GitHubListCommit): string {
+  return commit.author?.login || commit.commit.author.name || '';
+}
+
 function shouldSkipCommitAuthor(commit: GitHubListCommit): boolean {
-  const author = commit.author?.login || commit.commit.author.name || '';
-  const normalizedAuthor = author.toLowerCase();
+  const normalizedAuthor = getCommitAuthor(commit).toLowerCase();
 
   return SKIP_AUTHORS.some((skipAuthor) => normalizedAuthor.includes(skipAuthor.toLowerCase()));
+}
+
+function skipAsAutomatedAuthor(repoConfig: ChangelogRepository, commit: GitHubListCommit): boolean {
+  if (!shouldSkipCommitAuthor(commit)) {
+    return false;
+  }
+
+  const repo = `${repoConfig.owner}/${repoConfig.repo}`;
+  authorSkippedCommits.set(`${repo}@${commit.sha}`, {
+    repo,
+    sha: commit.sha,
+    url: commit.html_url,
+    author: getCommitAuthor(commit),
+  });
+
+  return true;
 }
 
 function truncateText(value: string, limit: number): string {
@@ -413,7 +443,7 @@ async function fetchRepositoryCommits(
     const response = await fetchGithubJson<GitHubListCommit[]>(url, token);
 
     for (const commit of response) {
-      if (shouldSkipCommitAuthor(commit)) {
+      if (skipAsAutomatedAuthor(repoConfig, commit)) {
         continue;
       }
 
@@ -658,7 +688,7 @@ export async function fetchApplicationReleaseCommits(
   );
 
   return commits
-    .filter((commit) => !shouldSkipCommitAuthor(commit))
+    .filter((commit) => !skipAsAutomatedAuthor(CHANGELOG_APPLICATION_REPOSITORY, commit))
     .map((commit) => normalizeCommit(CHANGELOG_APPLICATION_REPOSITORY, commit));
 }
 
@@ -720,7 +750,7 @@ export async function expandReleasedBrowserCommits(
       }
 
       for (const comparedCommit of comparedCommits) {
-        if (shouldSkipCommitAuthor(comparedCommit)) {
+        if (skipAsAutomatedAuthor(source.repository, comparedCommit)) {
           continue;
         }
 
@@ -928,7 +958,7 @@ function buildPrBody(
   draftPath: string,
   windowSelection: WindowSelection,
   draft: DraftResult,
-  sourceExclusions: ExclusionSummary[],
+  ledger: EvidenceLedger,
   cover: CoverResult | null = null,
 ): string {
   const sections = [
@@ -939,7 +969,7 @@ function buildPrBody(
     `- Window: \`${windowSelection.since}\` to \`${windowSelection.until}\``,
     `- Window source: \`${windowSelection.source}\``,
     `- Timezone reference: \`${CHANGELOG_TIMEZONE}\``,
-    '- The MDX draft is intentionally clean. Commit references for kept items are listed below for review.',
+    '- The MDX draft is intentionally clean. Commit references for kept and dropped items are listed below for review.',
     cover
       ? `- Cover image: \`${cover.src}\` (the undithered original is in the run artifacts for palette retries)`
       : `- Placeholder image: \`${CHANGELOG_PLACEHOLDER_IMAGE.src}\` (no cover was generated; see the run log)`,
@@ -966,21 +996,7 @@ function buildPrBody(
     }
   }
 
-  if (sourceExclusions.length > 0 || draft.discardedItems.length > 0) {
-    sections.push(
-      '## Source filtering',
-      '',
-      'Only aggregate counts are shown here so excluded internal source details are not copied into this public PR.',
-      '',
-    );
-    for (const item of sourceExclusions) {
-      sections.push(`- \`${item.reason}\`: ${item.count}`);
-    }
-
-    if (draft.discardedItems.length > 0) {
-      sections.push(`- \`model_discarded\`: ${draft.discardedItems.length}`);
-    }
-  }
+  sections.push('', ...renderSourceFilteringSection(ledger));
 
   return sections.join('\n').trimEnd() + '\n';
 }
@@ -1329,7 +1345,7 @@ export async function createPreviewWorkspace(input: {
   applicationReleaseBaseSha: string;
   applicationReleaseHeadSha: string;
   eligibleGroups: ChangeGroup[];
-  excludedGroups: ExcludedChangeGroup[];
+  ledger: EvidenceLedger;
 }): Promise<PreviewWorkspace> {
   const numberLabel = formatChangelogNumber(input.number);
   const directory = await fs.mkdtemp(
@@ -1337,17 +1353,6 @@ export async function createPreviewWorkspace(input: {
   );
   const draftFilename = `changelog-${numberLabel}-preview.mdx`;
   const sourceFacts = `[\n${input.eligibleGroups.map(formatChangeGroupForPrompt).join(',\n')}\n]\n`;
-  // Excluded details stay out of the public PR body; this local file is the audit trail for them.
-  const excludedGroups = input.excludedGroups.map((item) => ({
-    reason: item.reason,
-    key: item.group.key,
-    pullRequest: item.group.pullRequest,
-    commits: item.group.commits.map((commit) => ({
-      sha: commit.sha,
-      url: commit.url,
-      subject: commit.subject,
-    })),
-  }));
   const manifest = {
     changelogNumber: input.number,
     window: input.windowSelection,
@@ -1361,14 +1366,19 @@ export async function createPreviewWorkspace(input: {
 
   await Promise.all([
     fs.writeFile(path.join(directory, 'source-facts.json'), sourceFacts),
-    fs.writeFile(
-      path.join(directory, 'excluded-groups.json'),
-      `${JSON.stringify(excludedGroups, null, 2)}\n`,
-    ),
+    writePreviewLedger(directory, input.ledger),
     fs.writeFile(path.join(directory, 'run.json'), `${JSON.stringify(manifest, null, 2)}\n`),
   ]);
 
   return { directory, draftFilename };
+}
+
+/**
+ * Preview mode has no repository to commit the ledger into, so it lands beside the other evidence.
+ * It is written before the model runs and again afterwards, once the model's own discards are known.
+ */
+function writePreviewLedger(directory: string, ledger: EvidenceLedger): Promise<void> {
+  return fs.writeFile(path.join(directory, 'ledger.json'), `${JSON.stringify(ledger, null, 2)}\n`);
 }
 
 async function writePreviewDraftArtifacts(input: {
@@ -1377,19 +1387,20 @@ async function writePreviewDraftArtifacts(input: {
   windowSelection: WindowSelection;
   draft: DraftResult;
   mdx: string;
-  exclusionSummary: ExclusionSummary[];
+  ledger: EvidenceLedger;
 }) {
   const review = buildPrBody(
     input.number,
     input.workspace.draftFilename,
     input.windowSelection,
     input.draft,
-    input.exclusionSummary,
+    input.ledger,
   );
 
   await Promise.all([
     fs.writeFile(path.join(input.workspace.directory, input.workspace.draftFilename), input.mdx),
     fs.writeFile(path.join(input.workspace.directory, 'review.md'), review),
+    writePreviewLedger(input.workspace.directory, input.ledger),
     fs.writeFile(
       path.join(input.workspace.directory, 'model-output.json'),
       `${JSON.stringify(input.draft, null, 2)}\n`,
@@ -1400,6 +1411,7 @@ async function writePreviewDraftArtifacts(input: {
 export async function main(argv = process.argv.slice(2)) {
   const options = parseArgs(argv);
   const githubToken = getGithubToken();
+  authorSkippedCommits.clear();
   let nextNumber: number;
   let windowSelection: WindowSelection;
   let applicationReleaseBaseSha: string;
@@ -1489,6 +1501,17 @@ export async function main(argv = process.argv.slice(2)) {
   const groups = groupCommitsByPullRequest(commits);
   const { eligible, excluded } = filterEligibleChangeGroups(groups);
   const exclusionSummary = summarizeExcludedChangeGroups(excluded);
+  const buildLedger = (discardedItems: DiscardedItem[]) =>
+    buildEvidenceLedger({
+      changelogNumber: nextNumber,
+      windowSelection,
+      commitsCollected: commits.length,
+      authorSkipped: [...authorSkippedCommits.values()],
+      logicalChanges: groups.length,
+      eligibleGroups: eligible,
+      excludedGroups: excluded,
+      discardedItems,
+    });
 
   console.log(
     `Collected ${commits.length} commits as ${groups.length} logical changes; ${eligible.length} are eligible.`,
@@ -1508,7 +1531,7 @@ export async function main(argv = process.argv.slice(2)) {
         applicationReleaseBaseSha,
         applicationReleaseHeadSha: applicationReleaseSha,
         eligibleGroups: eligible,
-        excludedGroups: excluded,
+        ledger: buildLedger([]),
       })
     : null;
   if (previewWorkspace) {
@@ -1519,6 +1542,8 @@ export async function main(argv = process.argv.slice(2)) {
     console.log(
       'The source window contains no public changelog facts. Treating it as a quiet week.',
     );
+    // A quiet week opens no pull request, so the run log is the only place the reasoning survives.
+    console.log(renderSourceFilteringSection(buildLedger([])).join('\n'));
     if (!options.preview) {
       await appendGithubOutput('has_changes', 'false');
     }
@@ -1527,8 +1552,10 @@ export async function main(argv = process.argv.slice(2)) {
 
   const openAiToken = getOpenAiToken();
   const draft = await requestDraftFromModel(eligible, nextNumber, windowSelection, openAiToken);
+  const ledger = buildLedger(draft.discardedItems);
   if (!draft.sections.some((section) => section.entries.length > 0)) {
     console.log('The model found no publishable changelog entries. Treating it as a quiet week.');
+    console.log(renderSourceFilteringSection(ledger).join('\n'));
     if (!options.preview) {
       await appendGithubOutput('has_changes', 'false');
     }
@@ -1544,7 +1571,7 @@ export async function main(argv = process.argv.slice(2)) {
       windowSelection,
       draft,
       mdx: buildMdxDocument(nextNumber, draft, publishedAt),
-      exclusionSummary,
+      ledger,
     });
     console.log(`Generated isolated preview at ${previewWorkspace.directory}`);
     return;
@@ -1573,15 +1600,9 @@ export async function main(argv = process.argv.slice(2)) {
   await updateChangelogMeta(slug);
   await updateChangelogLlms();
   await updateChangelogState(nextNumber, windowSelection.until, applicationReleaseSha);
+  const ledgerPath = await writeEvidenceLedger(process.cwd(), ledger);
 
-  const prBody = buildPrBody(
-    nextNumber,
-    draftPath,
-    windowSelection,
-    draft,
-    exclusionSummary,
-    cover,
-  );
+  const prBody = buildPrBody(nextNumber, draftPath, windowSelection, draft, ledger, cover);
   const prBodyPath =
     process.env.CHANGELOG_PR_BODY_PATH ||
     path.join(os.tmpdir(), `steel-changelog-pr-body-${slug}.md`);
@@ -1594,11 +1615,13 @@ export async function main(argv = process.argv.slice(2)) {
   await appendGithubOutput('commit_message', prTitle);
   await appendGithubOutput('pr_body_path', prBodyPath);
   await appendGithubOutput('draft_path', draftPath);
+  await appendGithubOutput('ledger_path', ledgerPath);
   if (cover) {
     await appendGithubOutput('cover_workdir', cover.workdir);
   }
 
   console.log(`Generated ${draftPath}`);
+  console.log(`Wrote the evidence ledger to ${ledgerPath}`);
   console.log(`Prepared PR body at ${prBodyPath}`);
 }
 

--- a/tests/changelog-v2.test.ts
+++ b/tests/changelog-v2.test.ts
@@ -10,8 +10,17 @@ import {
   COVER_MOTIF_CHAR_LIMIT,
   DEFAULT_OPENAI_MODEL,
   DEFAULT_OPENAI_REASONING_EFFORT,
+  NEEDS_REVIEW_PR_BODY_LIMIT,
 } from '../scripts/changelog/config';
 import { generateChangelogCover } from '../scripts/changelog/cover';
+import {
+  buildEvidenceLedger,
+  getEvidenceLedgerPath,
+  getExclusionConfidence,
+  getRepositoryVisibility,
+  renderSourceFilteringSection,
+  writeEvidenceLedger,
+} from '../scripts/changelog/ledger';
 import {
   cleanPullRequestBody,
   filterEligibleChangeGroups,
@@ -48,6 +57,27 @@ import {
   PREVIOUS_CHANGELOG_CUTOFF,
   QUIET_WEEK_COMMITS,
 } from './fixtures/changelog-v2';
+
+const QUIET_WEEK_WINDOW = resolvePreviewWindow({
+  since: '2026-07-17T15:58:38.000Z',
+  until: PREVIOUS_CHANGELOG_CUTOFF,
+});
+
+function quietWeekLedger(changelogNumber = 36) {
+  const groups = groupCommitsByPullRequest(QUIET_WEEK_COMMITS);
+  const { eligible, excluded } = filterEligibleChangeGroups(groups);
+
+  return buildEvidenceLedger({
+    changelogNumber,
+    windowSelection: QUIET_WEEK_WINDOW,
+    commitsCollected: QUIET_WEEK_COMMITS.length,
+    authorSkipped: [],
+    logicalChanges: groups.length,
+    eligibleGroups: eligible,
+    excludedGroups: excluded,
+    discardedItems: [],
+  });
+}
 
 describe('changelog v2 source evidence', () => {
   test('groups merge and constituent commits into one logical pull request', () => {
@@ -228,6 +258,28 @@ describe('changelog v2 eligibility', () => {
     });
   });
 
+  test('keeps the repository visibility explicit', () => {
+    expect(
+      Object.fromEntries(
+        CHANGELOG_REPOSITORIES.map((repository) => [
+          `${repository.owner}/${repository.repo}`,
+          repository.visibility,
+        ]),
+      ),
+    ).toEqual({
+      '0xnenlabs/steel': 'private',
+      'steel-dev/steel-browser': 'public',
+      'steel-dev/infra': 'private',
+      'steel-dev/surf.new': 'public',
+      'steel-dev/steel-cookbook': 'public',
+      'steel-dev/steel-mcp-server': 'public',
+      'steel-dev/leaderboard': 'public',
+      'steel-dev/awesome-web-agents': 'public',
+      'steel-dev/cli': 'public',
+      'steel-dev/docs': 'public',
+    });
+  });
+
   for (const fixture of POLICY_FIXTURES) {
     test(`${fixture.label}: ${fixture.reason}`, () => {
       const groups = groupCommitsByPullRequest([fixture.commit]);
@@ -320,6 +372,230 @@ describe('changelog v2 eligibility', () => {
     } finally {
       globalThis.fetch = originalFetch;
     }
+  });
+});
+
+describe('changelog v2 evidence ledger', () => {
+  test('records every excluded group with a reason and a review confidence', () => {
+    const { excluded } = filterEligibleChangeGroups(groupCommitsByPullRequest(QUIET_WEEK_COMMITS));
+    const ledger = quietWeekLedger();
+
+    expect(ledger.exclusions).toHaveLength(excluded.length);
+    expect(ledger.exclusions.every((entry) => entry.reason && entry.repo)).toBe(true);
+    expect(new Set(ledger.exclusions.map((entry) => entry.confidence))).toEqual(
+      new Set(['heuristic', 'structural']),
+    );
+  });
+
+  test('separates rules worth re-reading from structural ones', () => {
+    // Regex and commit-type rules are where a real change can be lost, so they
+    // are the ones a reviewer has to confirm by hand.
+    expect(getExclusionConfidence('non_material_docs')).toBe('heuristic');
+    expect(getExclusionConfidence('routine_maintenance')).toBe('heuristic');
+    expect(getExclusionConfidence('internal_only')).toBe('heuristic');
+    expect(getExclusionConfidence('benchmark_maintenance')).toBe('heuristic');
+    expect(getExclusionConfidence('non_recipe_change')).toBe('heuristic');
+    // Lost changed-file evidence is structural but still needs eyes, because the
+    // group was dropped for missing data rather than for being uninteresting.
+    expect(getExclusionConfidence('missing_changed_files')).toBe('heuristic');
+
+    expect(getExclusionConfidence('self_generated')).toBe('structural');
+    expect(getExclusionConfidence('automated_author')).toBe('structural');
+    expect(getExclusionConfidence('disabled_source')).toBe('structural');
+    expect(getExclusionConfidence('ecosystem_listing')).toBe('structural');
+    expect(getExclusionConfidence('ignored_files_only')).toBe('structural');
+    expect(getExclusionConfidence('submodule_pointer_only')).toBe('structural');
+  });
+
+  test('redacts private repository prose while keeping a clickable trail', () => {
+    const ledger = quietWeekLedger();
+    const privateEntries = ledger.exclusions.filter((entry) => entry.visibility === 'private');
+    const serialized = JSON.stringify(privateEntries);
+
+    expect(privateEntries.length).toBeGreaterThan(0);
+    expect(privateEntries.every((entry) => entry.redacted)).toBe(true);
+    expect(serialized).not.toContain('JetStream');
+    expect(serialized).not.toContain('update dependencies');
+    expect(serialized).not.toContain('improve session reliability');
+    expect(serialized).not.toContain('package.json');
+    expect(serialized).toContain('0xnenlabs/steel');
+    expect(privateEntries.every((entry) => entry.commits.every((commit) => commit.url))).toBe(true);
+    expect(privateEntries.every((entry) => entry.changedFileCount > 0)).toBe(true);
+  });
+
+  test('keeps public repository detail intact', () => {
+    const ledger = quietWeekLedger();
+    const docsEntry = ledger.exclusions.find((entry) => entry.reason === 'non_material_docs');
+
+    expect(docsEntry?.repo).toBe('steel-dev/docs');
+    expect(docsEntry?.redacted).toBe(false);
+    expect(docsEntry?.commits[0]?.subject).toBe('docs(seo): cross-link topic hubs');
+    expect(docsEntry?.changedFiles).toContain('content/docs/guides/browser.mdx');
+  });
+
+  test('treats an unconfigured repository as private', () => {
+    expect(getRepositoryVisibility('steel-dev', 'docs')).toBe('public');
+    expect(getRepositoryVisibility('0xnenlabs', 'steel')).toBe('private');
+    expect(getRepositoryVisibility('steel-dev', 'not-yet-monitored')).toBe('private');
+  });
+
+  test('reconciles collected commits against eligible and excluded groups', () => {
+    const ledger = quietWeekLedger();
+
+    expect(ledger.reconciliation.commitsCollected).toBe(QUIET_WEEK_COMMITS.length);
+    expect(ledger.reconciliation.eligible).toBe(0);
+    expect(ledger.reconciliation.excluded).toBe(ledger.exclusions.length);
+    expect(ledger.reconciliation.logicalChanges).toBe(ledger.reconciliation.excluded);
+    expect(ledger.reconciliation.unaccounted).toBe(0);
+  });
+
+  test('surfaces groups that vanished between grouping and classification', () => {
+    const groups = groupCommitsByPullRequest(QUIET_WEEK_COMMITS);
+    const { eligible, excluded } = filterEligibleChangeGroups(groups);
+    const ledger = buildEvidenceLedger({
+      changelogNumber: 36,
+      windowSelection: QUIET_WEEK_WINDOW,
+      commitsCollected: QUIET_WEEK_COMMITS.length,
+      authorSkipped: [],
+      logicalChanges: groups.length + 2,
+      eligibleGroups: eligible,
+      excludedGroups: excluded,
+      discardedItems: [],
+    });
+
+    expect(ledger.reconciliation.unaccounted).toBe(2);
+    expect(renderSourceFilteringSection(ledger).join('\n')).toContain('2 unaccounted');
+  });
+
+  test('records commits dropped by author before they reach a group', () => {
+    const groups = groupCommitsByPullRequest(QUIET_WEEK_COMMITS);
+    const { eligible, excluded } = filterEligibleChangeGroups(groups);
+    const ledger = buildEvidenceLedger({
+      changelogNumber: 36,
+      windowSelection: QUIET_WEEK_WINDOW,
+      commitsCollected: QUIET_WEEK_COMMITS.length,
+      authorSkipped: [
+        {
+          repo: 'steel-dev/docs',
+          sha: 'e'.repeat(40),
+          url: `https://github.com/steel-dev/docs/commit/${'e'.repeat(40)}`,
+          author: 'github-actions[bot]',
+        },
+      ],
+      logicalChanges: groups.length,
+      eligibleGroups: eligible,
+      excludedGroups: excluded,
+      discardedItems: [],
+    });
+
+    expect(ledger.reconciliation.authorSkippedCommits).toBe(1);
+    expect(ledger.authorSkipped[0].author).toBe('github-actions[bot]');
+    expect(renderSourceFilteringSection(ledger).join('\n')).toContain(
+      '1 skipped as an automated author before grouping',
+    );
+  });
+
+  test('carries the model discard list with its stated reasons', () => {
+    const groups = groupCommitsByPullRequest(QUIET_WEEK_COMMITS);
+    const { eligible, excluded } = filterEligibleChangeGroups(groups);
+    const ledger = buildEvidenceLedger({
+      changelogNumber: 36,
+      windowSelection: QUIET_WEEK_WINDOW,
+      commitsCollected: QUIET_WEEK_COMMITS.length,
+      authorSkipped: [],
+      logicalChanges: groups.length,
+      eligibleGroups: eligible,
+      excludedGroups: excluded,
+      discardedItems: [
+        {
+          text: 'Renamed an internal helper.',
+          reason: 'No user-facing effect.',
+          references: [
+            { label: 'docs d8dd806', url: 'https://github.com/steel-dev/docs/commit/d8dd806' },
+          ],
+        },
+      ],
+    });
+    const rendered = renderSourceFilteringSection(ledger).join('\n');
+
+    expect(ledger.modelDiscarded).toHaveLength(1);
+    expect(ledger.modelDiscarded[0].reason).toBe('No user-facing effect.');
+    expect(rendered).toContain('No user-facing effect.');
+  });
+
+  test('drops model discard prose that leans on private evidence', () => {
+    const groups = groupCommitsByPullRequest(QUIET_WEEK_COMMITS);
+    const { eligible, excluded } = filterEligibleChangeGroups(groups);
+    const ledger = buildEvidenceLedger({
+      changelogNumber: 36,
+      windowSelection: QUIET_WEEK_WINDOW,
+      commitsCollected: QUIET_WEEK_COMMITS.length,
+      authorSkipped: [],
+      logicalChanges: groups.length,
+      eligibleGroups: eligible,
+      excludedGroups: excluded,
+      discardedItems: [
+        {
+          text: 'Reworked the PuppetMaster fleet controller.',
+          reason: 'Internal plumbing.',
+          references: [
+            { label: 'steel 12d54db', url: 'https://github.com/0xnenlabs/steel/commit/12d54db' },
+          ],
+        },
+      ],
+    });
+
+    expect(ledger.modelDiscarded[0].redacted).toBe(true);
+    expect(ledger.modelDiscarded[0].text).toBeNull();
+    expect(ledger.modelDiscarded[0].reason).toBe('Internal plumbing.');
+    expect(JSON.stringify(ledger)).not.toContain('PuppetMaster fleet controller');
+  });
+
+  test('puts heuristic exclusions in an open list and structural ones behind a fold', () => {
+    const rendered = renderSourceFilteringSection(quietWeekLedger()).join('\n');
+    const foldIndex = rendered.indexOf('<details>');
+
+    expect(foldIndex).toBeGreaterThan(-1);
+    expect(rendered).toContain('### Needs review');
+    expect(rendered.slice(0, foldIndex)).toContain('`non_material_docs`');
+    expect(rendered.slice(foldIndex)).toContain('`ecosystem_listing`');
+    expect(rendered).not.toContain('Only aggregate counts are shown here');
+  });
+
+  test('caps the needs-review list and says how many it left out', () => {
+    const overflow = Array.from({ length: NEEDS_REVIEW_PR_BODY_LIMIT + 3 }, (_, index) =>
+      commitFixture('docs', {
+        repo: 'docs',
+        sha: `${index}`.padStart(40, 'a'),
+        shortSha: `${index}`.padStart(7, 'a'),
+        subject: `docs(seo): cross-link topic hub ${index}`,
+        changedFiles: [changedFile(`content/docs/guides/hub-${index}.mdx`)],
+      }),
+    );
+    const groups = groupCommitsByPullRequest(overflow);
+    const { eligible, excluded } = filterEligibleChangeGroups(groups);
+    const ledger = buildEvidenceLedger({
+      changelogNumber: 36,
+      windowSelection: QUIET_WEEK_WINDOW,
+      commitsCollected: overflow.length,
+      authorSkipped: [],
+      logicalChanges: groups.length,
+      eligibleGroups: eligible,
+      excludedGroups: excluded,
+      discardedItems: [],
+    });
+    const rendered = renderSourceFilteringSection(ledger).join('\n');
+
+    expect(excluded).toHaveLength(NEEDS_REVIEW_PR_BODY_LIMIT + 3);
+    expect(ledger.exclusions).toHaveLength(NEEDS_REVIEW_PR_BODY_LIMIT + 3);
+    expect(rendered).toContain(`3 more heuristic exclusions are in the ledger`);
+  });
+
+  test('points at a committed ledger path per changelog number', () => {
+    expect(getEvidenceLedgerPath(36)).toBe('scripts/changelog/audit/036.json');
+    expect(renderSourceFilteringSection(quietWeekLedger()).join('\n')).toContain(
+      'scripts/changelog/audit/036.json',
+    );
   });
 });
 
@@ -654,38 +930,68 @@ describe('changelog v2 release evidence recovery', () => {
     }
   });
 
-  test('preview workspace records excluded groups for local audit', async () => {
-    const { excluded } = filterEligibleChangeGroups(groupCommitsByPullRequest(QUIET_WEEK_COMMITS));
+  test('preview workspace records the evidence ledger for local audit', async () => {
+    const groups = groupCommitsByPullRequest(QUIET_WEEK_COMMITS);
+    const { eligible, excluded } = filterEligibleChangeGroups(groups);
+    const windowSelection = resolvePreviewWindow({
+      since: '2026-07-17T15:58:38.000Z',
+      until: PREVIOUS_CHANGELOG_CUTOFF,
+    });
     const workspace = await createPreviewWorkspace({
       number: 35,
-      windowSelection: resolvePreviewWindow({
-        since: '2026-07-17T15:58:38.000Z',
-        until: PREVIOUS_CHANGELOG_CUTOFF,
-      }),
+      windowSelection,
       applicationReleaseBaseSha: 'a'.repeat(40),
       applicationReleaseHeadSha: 'b'.repeat(40),
       eligibleGroups: [],
-      excludedGroups: excluded,
+      ledger: buildEvidenceLedger({
+        changelogNumber: 35,
+        windowSelection,
+        commitsCollected: QUIET_WEEK_COMMITS.length,
+        authorSkipped: [],
+        logicalChanges: groups.length,
+        eligibleGroups: eligible,
+        excludedGroups: excluded,
+        discardedItems: [],
+      }),
     });
 
     try {
-      const raw = await fs.readFile(path.join(workspace.directory, 'excluded-groups.json'), 'utf8');
-      const parsed = JSON.parse(raw) as Array<{ reason: string; key: string }>;
+      const raw = await fs.readFile(path.join(workspace.directory, 'ledger.json'), 'utf8');
+      const parsed = JSON.parse(raw) as {
+        exclusions: Array<{ reason: string; key: string }>;
+      };
 
-      expect(parsed).toHaveLength(excluded.length);
-      expect(parsed.every((item) => item.reason && item.key)).toBe(true);
+      expect(parsed.exclusions).toHaveLength(excluded.length);
+      expect(parsed.exclusions.every((item) => item.reason && item.key)).toBe(true);
     } finally {
       await fs.rm(workspace.directory, { recursive: true, force: true });
     }
   });
 
-  test('preview CLI writes excluded evidence before returning for a quiet week', async () => {
+  test('writes the ledger under the audit directory for a production run', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'steel-changelog-audit-'));
+
+    try {
+      const written = await writeEvidenceLedger(root, quietWeekLedger(36));
+      const parsed = JSON.parse(await fs.readFile(path.join(root, written), 'utf8')) as {
+        changelogNumber: number;
+      };
+
+      expect(written).toBe('scripts/changelog/audit/036.json');
+      expect(parsed.changelogNumber).toBe(36);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('preview CLI writes the ledger before returning for a quiet week', async () => {
     const originalFetch = globalThis.fetch;
     const originalLog = console.log;
     const originalGithubToken = process.env.CHANGELOG_GITHUB_TOKEN;
     const originalOpenAiToken = process.env.OPENAI_API_KEY;
     const logs: string[] = [];
     const commitSha = 'c'.repeat(40);
+    const botSha = 'f'.repeat(40);
     const listCommit = {
       sha: commitSha,
       html_url: `https://github.com/0xnenlabs/steel/commit/${commitSha}`,
@@ -694,6 +1000,17 @@ describe('changelog v2 release evidence recovery', () => {
         message: 'chore: update dependencies',
         author: { name: 'Engineer', date: '2026-07-24T16:32:50.500Z' },
         committer: { date: '2026-07-24T16:32:50.500Z' },
+      },
+    };
+    // Author-skipped commits are dropped before grouping, so only the ledger can account for them.
+    const botCommit = {
+      sha: botSha,
+      html_url: `https://github.com/0xnenlabs/steel/commit/${botSha}`,
+      author: { login: 'github-actions[bot]' },
+      commit: {
+        message: 'chore: sync generated clients',
+        author: { name: 'github-actions[bot]', date: '2026-07-24T16:32:50.600Z' },
+        committer: { date: '2026-07-24T16:32:50.600Z' },
       },
     };
     let workspaceDirectory: string | undefined;
@@ -705,7 +1022,11 @@ describe('changelog v2 release evidence recovery', () => {
       const url = new URL(String(input));
 
       if (url.pathname.includes('/repos/0xnenlabs/steel/compare/')) {
-        return jsonResponse({ status: 'ahead', total_commits: 1, commits: [listCommit] });
+        return jsonResponse({
+          status: 'ahead',
+          total_commits: 2,
+          commits: [listCommit, botCommit],
+        });
       }
 
       if (url.pathname === `/repos/0xnenlabs/steel/commits/${commitSha}/pulls`) {
@@ -748,14 +1069,36 @@ describe('changelog v2 release evidence recovery', () => {
       expect(workspaceLog).toBeDefined();
       workspaceDirectory = workspaceLog?.replace('Prepared isolated preview evidence at ', '');
 
-      const excluded = JSON.parse(
-        await fs.readFile(path.join(workspaceDirectory as string, 'excluded-groups.json'), 'utf8'),
-      ) as Array<{ reason: string }>;
+      const ledger = JSON.parse(
+        await fs.readFile(path.join(workspaceDirectory as string, 'ledger.json'), 'utf8'),
+      ) as {
+        exclusions: Array<{ reason: string; redacted: boolean }>;
+        authorSkipped: Array<{ repo: string; sha: string; url: string; author: string }>;
+        reconciliation: {
+          commitsCollected: number;
+          authorSkippedCommits: number;
+          unaccounted: number;
+        };
+      };
       const sourceFacts = JSON.parse(
         await fs.readFile(path.join(workspaceDirectory as string, 'source-facts.json'), 'utf8'),
       ) as unknown[];
 
-      expect(excluded.map((item) => item.reason)).toEqual(['routine_maintenance']);
+      expect(ledger.exclusions.map((item) => item.reason)).toEqual(['routine_maintenance']);
+      expect(ledger.exclusions[0].redacted).toBe(true);
+      expect(ledger.reconciliation).toMatchObject({
+        commitsCollected: 1,
+        authorSkippedCommits: 1,
+        unaccounted: 0,
+      });
+      expect(ledger.authorSkipped).toEqual([
+        {
+          repo: '0xnenlabs/steel',
+          sha: botSha,
+          url: `https://github.com/0xnenlabs/steel/commit/${botSha}`,
+          author: 'github-actions[bot]',
+        },
+      ]);
       expect(sourceFacts).toEqual([]);
       expect(logs).toContain(
         'The source window contains no public changelog facts. Treating it as a quiet week.',


### PR DESCRIPTION
## Why

#112 reported `non_material_docs: 32` and nothing else, so there was no way to tell whether a real change had been dropped. The detail a reviewer needs was already being computed, then thrown away:

| Where | What it held | Written on a real run? |
|---|---|---|
| `generate-changelog-draft.ts:1341-1350` | per-group reason, PR, commit SHA + subject | No, only inside `createPreviewWorkspace` (gated on `options.preview`) |
| `model-output.json` | the model's `discardedItems` with reasons | No, preview only |
| PR body | reason counts | Yes |
| Workflow artifact upload | draft, PR body, cover workdir | Yes, and it carried no evidence |

Commits dropped by `shouldSkipCommitAuthor` never reached a change group either, so they were absent from every reason bucket with nothing reconciling the totals.

## What changed

**The ledger is built on every run** and committed to `scripts/changelog/audit/<n>.json`. Actions artifacts expire, so the committed file is what makes an exclusion answerable months later. It is also uploaded as a run artifact and rendered into the run log on a quiet week, when no PR exists to carry it.

**Exclusions are split by how much a reviewer has to trust them.** Heuristic reasons (`non_material_docs`, `routine_maintenance`, `internal_only`, `benchmark_maintenance`, `non_recipe_change`, plus `missing_changed_files` because it means lost evidence) come from regexes and commit types, so a real change can hide behind them. They get an open **Needs review** block in the PR body, capped at 10 with an explicit overflow line rather than a silent truncation. Structural reasons fold into a `<details>`.

**The reconciliation is stated**, so a silent drop is visible:

```
- Commits collected: 71 (3 skipped as an automated author before grouping)
- Logical changes: 40 (4 eligible, 36 excluded, 0 unaccounted)
```

**Redaction is driven by explicit repository visibility.** Five of six monitored repos are public; `0xnenlabs/steel` and `steel-dev/infra` are not, and public-repo artifacts and job logs are publicly downloadable, so there is no "keep it in CI" option. Private sources keep their links, SHAs, and file counts but not their pull request titles, commit subjects, or file paths. An unconfigured repository is treated as private, so a newly monitored source cannot leak before someone declares it. The same rule gates the model's discard prose: text survives only when every reference behind it is public.

A redacted heuristic row still tells a reviewer where to look:

```
- `internal_only` 0xnenlabs/steel [#812](https://github.com/0xnenlabs/steel/pull/812) (1 commit, 2 files)
```

## Testing

15 new cases in `tests/changelog-v2.test.ts` covering confidence classification, redaction in both directions, the unknown-repo default, reconciliation including the injected-drift case, the needs-review cap, and the rendered section layout. The preview CLI test now asserts the ledger records an author-skipped bot commit that never reaches a group, which is the hole that had no coverage at all.

`bun test tests/changelog-v2.test.ts` 67 pass, `bun run typecheck` and `bun run check` clean.

Unrelated and pre-existing on `main`: `tests/e2e/llm-endpoints.test.ts` fails on the homepage logo class assertion (`class="shrink-0"` vs `shrink-0 self-center sm:self-auto`), from 92581223. Left alone.