### PR TITLE
test(home): assert the hero logo keeps shrink-0 by class token

### DIFF
--- a/tests/e2e/llm-endpoints.test.ts
+++ b/tests/e2e/llm-endpoints.test.ts
@@ -59,6 +59,10 @@ function hasLinkRelation(response: Response, target: string, relation: string): 
     });
 }
 
+function classTokens(tag: string | undefined): string[] {
+  return (/class="([^"]*)"/.exec(tag ?? '')?.[1] ?? '').split(/\s+/).filter(Boolean);
+}
+
 function hasActiveNavLink(body: string, href: string): boolean {
   return [...body.matchAll(/<a\b[^>]*>/g)].some(
     ([tag]) => tag.includes(`href="${href}"`) && tag.includes('data-nav-active="true"'),
@@ -331,7 +335,9 @@ describe('.md suffix end-to-end', () => {
     expect(body.match(/<h1\b/g)).toHaveLength(1);
     expect(body.match(/<main\b/g)).toHaveLength(1);
     expect(body).toContain('<h1 class="text-3xl">Steel Documentation</h1>');
-    expect(animatedLogo).toContain('class="shrink-0"');
+    // The logo must keep shrink-0 so the hero's flex row cannot squash it. Responsive
+    // alignment classes come and go around it, so assert the token, not the whole attribute.
+    expect(classTokens(animatedLogo)).toContain('shrink-0');
     expect(body).toContain(
       'Steel is the open-source browser API for AI agents — managed cloud browsers with stealth, residential proxies, CAPTCHA solving, persistent profiles, session replays, and agent observability. Use these docs to create cloud browser sessions and connect your automation tools.',
     );


### PR DESCRIPTION
## Why

`tests/e2e/llm-endpoints.test.ts` has been failing on `main` since #115, which turns the `lint` check red on every open PR (including #112).

The assertion matched the entire `class` attribute as one string:

```ts
expect(animatedLogo).toContain('class="shrink-0"');
```

#115 stacked the hero content on mobile by changing the logo's className to `shrink-0 self-center sm:self-auto`. `shrink-0` is still there, so the invariant the test guards never regressed: the assertion was just pinned to an exact attribute value.

## What changed

A small `classTokens` helper (matching the file's existing `varyTokens` / `hasLinkRelation` style) parses the attribute into tokens, and the assertion checks membership:

```ts
expect(classTokens(animatedLogo)).toContain('shrink-0');
```

The meaningful invariant is that the logo keeps `shrink-0` so the hero's flex row cannot squash it. Responsive alignment classes around it are free to change without breaking the test.

## Testing

`bun test tests/e2e/llm-endpoints.test.ts` 23 pass (was 22 pass / 1 fail).

I confirmed the assertion is not vacuous: temporarily removing `shrink-0` from `app/(home)/_pages/page.en.tsx` makes it fail with `Expected to contain: "shrink-0"`, then restored the component.

`bun run check` and `bun run typecheck` clean. No production code touched.